### PR TITLE
feat(argo-workflow): Upgrade to 3.0.0

### DIFF
--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -244,9 +244,8 @@ spec:
       - args:
         - server
         - --namespaced
-#        - --auth-mode 
-#        - client
-        image: argoproj/argocli:v3.0.0
+        - --secure=false
+        image: argoproj/argocli:v3.0.1
         name: argo-server
         resources:
           requests:
@@ -293,7 +292,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0
+        - argoproj/argoexec:v3.0.1
         - --namespaced
         command:
         - workflow-controller
@@ -319,6 +318,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.0
+        image: argoproj/workflow-controller:v3.0.1
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -246,7 +246,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v3.0.0-rc6
+        image: argoproj/argocli:v3.0.0-rc8
         name: argo-server
         resources:
           requests:
@@ -293,7 +293,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0-rc6
+        - argoproj/argoexec:v3.0.0-rc8
         - --namespaced
         command:
         - workflow-controller
@@ -319,6 +319,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.0-rc6
+        image: argoproj/workflow-controller:v3.0.0-rc8
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -246,7 +246,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v3.0.0-rc5
+        image: argoproj/argocli:v3.0.0-rc6
         name: argo-server
         resources:
           requests:
@@ -293,7 +293,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0-rc5
+        - argoproj/argoexec:v3.0.0-rc6
         - --namespaced
         command:
         - workflow-controller
@@ -319,6 +319,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.0-rc5
+        image: argoproj/workflow-controller:v3.0.0-rc6
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -184,6 +184,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: workflow-controller-configmap
+data:
+  containerRuntimeExecutor: k8sapi
+  metricsConfig: |
+    enabled: true
+    path: /metrics
+    port: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -240,7 +246,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v3.0.0-rc2
+        image: argoproj/argocli:v3.0.0-rc3
         name: argo-server
         resources:
           requests:
@@ -287,7 +293,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0-rc2
+        - argoproj/argoexec:v3.0.0-rc3
         - --namespaced
         command:
         - workflow-controller
@@ -313,6 +319,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.0-rc2
+        image: argoproj/workflow-controller:v3.0.0-rc3
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -245,7 +245,7 @@ spec:
         - server
         - --namespaced
         - --secure=false
-        image: argoproj/argocli:v3.0.1
+        image: argoproj/argocli:v3.0.2
         name: argo-server
         resources:
           requests:
@@ -292,7 +292,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.1
+        - argoproj/argoexec:v3.0.2
         - --namespaced
         command:
         - workflow-controller
@@ -318,6 +318,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.1
+        image: argoproj/workflow-controller:v3.0.2
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -184,16 +184,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: workflow-controller-configmap
-data:
-  config: | 
-    containerRuntimeExecutor: k8sapi
-    featureFlags:
-      resourcesDuration: true
-    metricsConfig:
-      disableLegacy: true
-      enabled: true
-      path: /metrics
-      port: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -210,7 +200,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: workflow-controller
+  name: workflow-controller-metrics
   labels:
     app: workflow-controller
     app.kubernetes.io/name: workflow-controller
@@ -250,7 +240,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v3.0.0-rc1
+        image: argoproj/argocli:v3.0.0-rc2
         name: argo-server
         resources:
           requests:
@@ -297,7 +287,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0-rc1
+        - argoproj/argoexec:v3.0.0-rc2
         - --namespaced
         command:
         - workflow-controller
@@ -316,6 +306,13 @@ spec:
             memory: 15Gi
         ports:
         - containerPort: 8080
-        image: argoproj/workflow-controller:v3.0.0-rc1
+          name: metrics
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        image: argoproj/workflow-controller:v3.0.0-rc2
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -246,7 +246,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v3.0.0-rc9
+        image: argoproj/argocli:v3.0.0
         name: argo-server
         resources:
           requests:
@@ -293,7 +293,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0-rc9
+        - argoproj/argoexec:v3.0.0
         - --namespaced
         command:
         - workflow-controller
@@ -319,6 +319,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.0-rc9
+        image: argoproj/workflow-controller:v3.0.0
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -246,7 +246,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v3.0.0-rc4
+        image: argoproj/argocli:v3.0.0-rc5
         name: argo-server
         resources:
           requests:
@@ -293,7 +293,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0-rc4
+        - argoproj/argoexec:v3.0.0-rc5
         - --namespaced
         command:
         - workflow-controller
@@ -319,6 +319,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.0-rc4
+        image: argoproj/workflow-controller:v3.0.0-rc5
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -246,7 +246,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v3.0.0-rc3
+        image: argoproj/argocli:v3.0.0-rc4
         name: argo-server
         resources:
           requests:
@@ -293,7 +293,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0-rc3
+        - argoproj/argoexec:v3.0.0-rc4
         - --namespaced
         command:
         - workflow-controller
@@ -319,6 +319,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.0-rc3
+        image: argoproj/workflow-controller:v3.0.0-rc4
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -246,7 +246,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v3.0.0-rc8
+        image: argoproj/argocli:v3.0.0-rc9
         name: argo-server
         resources:
           requests:
@@ -293,7 +293,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v3.0.0-rc8
+        - argoproj/argoexec:v3.0.0-rc9
         - --namespaced
         command:
         - workflow-controller
@@ -319,6 +319,6 @@ spec:
             port: metrics
           initialDelaySeconds: 30
           periodSeconds: 30
-        image: argoproj/workflow-controller:v3.0.0-rc8
+        image: argoproj/workflow-controller:v3.0.0-rc9
         name: workflow-controller
       serviceAccountName: argo

--- a/argo-workflow/argo-install.yaml
+++ b/argo-workflow/argo-install.yaml
@@ -14,6 +14,14 @@ metadata:
   name: argo-role
 rules:
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - ""
   resources:
   - pods
@@ -242,7 +250,7 @@ spec:
         - --namespaced
 #        - --auth-mode 
 #        - client
-        image: argoproj/argocli:v2.11.7
+        image: argoproj/argocli:v3.0.0-rc1
         name: argo-server
         resources:
           requests:
@@ -289,10 +297,16 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:v2.11.7
+        - argoproj/argoexec:v3.0.0-rc1
         - --namespaced
         command:
         - workflow-controller
+        env:
+        - name: LEADER_ELECTION_IDENTITY
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         resources:
           requests:
             cpu: 200m
@@ -302,6 +316,6 @@ spec:
             memory: 15Gi
         ports:
         - containerPort: 8080
-        image: argoproj/workflow-controller:v2.11.7
+        image: argoproj/workflow-controller:v3.0.0-rc1
         name: workflow-controller
       serviceAccountName: argo


### PR DESCRIPTION
## Why change 

To upgrade Argo Workflow to the latest version `3.0.0`

## Description

This PR is a draft until the final `3.0.0` is released.
This PR allows testing recent release candidates.

## Release history
- `3.0.2`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.2
- `3.0.1`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.1
- `3.0.0`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0
- `3.0.0-rc9`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0-rc9
- `3.0.0-rc8`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0-rc8
- `3.0.0-rc6`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0-rc6
- `3.0.0-rc5`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0-rc5
- `3.0.0-rc4`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0-rc4
- `3.0.0-rc3`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0-rc3
- `3.0.0-rc2`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0-rc2
- `3.0.0-rc1`: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0-rc1

## New features in manifest
-  env var `LEADER_ELECTION_IDENTITY`: https://github.com/argoproj/argo-cd/issues/3073
- `lease` resource

## Ref

- https://github.com/coreweave/infra-pm/issues/14
- https://github.com/argoproj/argo/pull/4679

# TODO
- [x] - `FAIL HOSTS` - does not display, https://github.com/argoproj/argo/issues/5054
- [x] - test concierge in own namespace
- [x] - wait for final release: https://github.com/argoproj/argo-workflows/releases/tag/v3.0.0
- [x] - retest final version with concierge
- [x] - apply to concierge https://github.com/coreweave/concierge-backend/pull/477
- [ ] - apply https://github.com/coreweave/kube-charts/pull/30