### PR TITLE
fix(docs) Add VirtualServer VMI case to pvc-clone.sh

### DIFF
--- a/virtual-server/pvc-clone.sh
+++ b/virtual-server/pvc-clone.sh
@@ -18,8 +18,12 @@ get_field() {
 if kubectl get vmi $SRC &>/dev/null; then
     echo "Found running VM instance: $SRC"
     read -p "Stop it? [y/N] " STOP
-
-    SRC_PVC=$(get_field vmi $SRC ".spec.volumes[?(@.name=='dv')].persistentVolumeClaim.claimName")
+    
+	if [ "$(get_field vmi $SRC ".metadata.annotations.vs\.coreweave\.com/vmi")" == "true" ]; then
+	SRC_PVC=$(get_field vmi $SRC ".spec.volumes..dataVolume.name")
+	else
+	SRC_PVC=$(get_field vmi $SRC ".spec.volumes[?(@.name=='dv')].persistentVolumeClaim.claimName")
+	fi
 
     if [[ "$STOP" =~ ^[yY]$ ]]; then
         virtctl stop $SRC


### PR DESCRIPTION
This PR adds a case for identifying PVC for a VirtualServer VMI as well as a Helm VMI.

This is needed due to the difference in spec: 

`k get vmi -o json`

Helm VMI:
```
"volumes": [
            {
                "name": "dv",
                "persistentVolumeClaim": {
                    "claimName": "vs-windows10"
                }
            }, 
```
VS VMI:
```
        "volumes": [
            {
                "dataVolume": {
                    "name": "vs-windows10"
                },
                "name": "root"
            },
```