### PR TITLE
feat(vso): Add ephemeral disk example

### DIFF
--- a/virtual-server/examples/kubectl/virtual-server-block-pvc.yaml
+++ b/virtual-server/examples/kubectl/virtual-server-block-pvc.yaml
@@ -34,7 +34,7 @@ spec:
       source:
         pvc:
           namespace: vd-images
-          name: ubuntu2004-nvidia-510-47-03-1-docker-master-20220421-ord1
+          name: ubuntu2004-nvidia-510-47-03-1-docker-master-20220517-ord1
     additionalDisks:
       - name: additional-block-volume
         spec:

--- a/virtual-server/examples/kubectl/virtual-server-ephemeral-disk.yaml
+++ b/virtual-server/examples/kubectl/virtual-server-ephemeral-disk.yaml
@@ -18,7 +18,7 @@ spec:
       source:
         pvc:
           namespace: vd-images
-          name: ubuntu2004-docker-master-20211208-ord1
+          name: ubuntu2004-docker-master-20220708-ord1
     additionalDisks:
       - name: ephemeral-disk
         spec:

--- a/virtual-server/examples/kubectl/virtual-server-ephemeral-disk.yaml
+++ b/virtual-server/examples/kubectl/virtual-server-ephemeral-disk.yaml
@@ -1,0 +1,47 @@
+apiVersion: virtualservers.coreweave.com/v1alpha1
+kind: VirtualServer
+metadata:
+  name: vs-ubuntu2004-ephemeral-disk
+spec:
+  region: ORD1
+  os:
+    type: linux
+  resources:
+    cpu:
+      count: 2
+      type: intel-xeon-v4
+    memory: 4Gi
+  storage:
+    root:
+      size: 40Gi
+      storageClassName: block-nvme-ord1
+      source:
+        pvc:
+          namespace: vd-images
+          name: ubuntu2004-docker-master-20211208-ord1
+    additionalDisks:
+      - name: ephemeral-disk
+        spec:
+          emptyDisk:
+            capacity: 10Gi
+#  users:
+#    - username: SET YOUR USERNAME HERE
+#      password: SET YOUR PASSWORD HERE  
+      # To use key-based authentication replace and uncomment ssh-rsa below with your public ssh key
+      # sshpublickey: |
+      #  ssh-rsa AAAAB3NzaC1yc2EAAAA ... user@hostname
+  network:
+    public: true
+    tcp:
+      ports:
+        - 22
+  # Format and mount the ephemeral disk
+  cloudInit: |
+    bootcmd:
+      - test "$(lsblk /dev/vdb)" && mkfs.ext4 /dev/vdb
+      - mkdir -p /mnt/vdb
+    mounts:
+    - [ "/dev/vdb", "/mnt/vdb", "ext4", "defaults,nofail", "0", "2" ]
+    runcmd:
+      - [df, -h]
+  initializeRunning: true

--- a/virtual-server/examples/kubectl/virtual-server-shared-pvc.yaml
+++ b/virtual-server/examples/kubectl/virtual-server-shared-pvc.yaml
@@ -33,7 +33,7 @@ spec:
       source:
         pvc:
           namespace: vd-images
-          name: ubuntu2004-docker-master-20210323-ord1
+          name: ubuntu2004-nvidia-510-47-03-1-docker-master-20220517-ord1
     filesystems:
       - name: shared-pvc
         spec:


### PR DESCRIPTION
This PR adds an example with the ephemeral disk.

The disk is automatically formatted and mounted to `/mnt/vdb` via `cloud-init` script.

Additionally, I updated old root sources.

## Ref

fix https://github.com/coreweave/virtual-server-operator/issues/48