### PR TITLE
feat(vso): Add static mac address example cli

### DIFF
--- a/virtual-server/examples/kubectl/virtual-server-static-mac.yaml
+++ b/virtual-server/examples/kubectl/virtual-server-static-mac.yaml
@@ -1,0 +1,37 @@
+apiVersion: virtualservers.coreweave.com/v1alpha1
+kind: VirtualServer
+metadata:
+  name: example-vs-static-mac
+spec:
+  region: ORD1
+  os:
+    type: linux
+  resources:
+    cpu:
+      count: 2
+      type: amd-epyc-rome
+    memory: 2Gi
+  storage:
+    root:
+      size: 40Gi
+      storageClassName: block-nvme-ord1
+      source:
+        pvc:
+          namespace: vd-images
+          name: ubuntu2004-docker-master-20220103-ord1
+  # Change user name and pasword
+  # User is on the sudoers list
+  #  users:
+  #    - username: SET YOUR USERNAME HERE
+  #      password: SET YOUR PASSWORD HERE  
+  # To use key-based authentication replace and uncomment ssh-rsa below with your public ssh key
+  #  sshpublickey: |
+  #    ssh-rsa AAAAB3NzaC1yc2EAAAA ... user@hostname
+  network:
+    macAddress: A2-1F-EE-09-06-5D
+    public: true
+    tcp:
+      ports:
+        - 22
+  initializeRunning: true
+


### PR DESCRIPTION
This PR adds an example with a static mac address.

The mac address in VS is `A2-1F-EE-09-06-5D` and the same in VMI:

```
john@example-vs-static-mac:~$ ifconfig
docker0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        inet 192.168.99.1  netmask 255.255.255.0  broadcast 192.168.99.255
        ether 02:42:0c:34:e8:11  txqueuelen 0  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

enp1s0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.146.48.242  netmask 255.255.255.255  broadcast 0.0.0.0
        inet6 fe80::a01f:eeff:fe09:65d  prefixlen 64  scopeid 0x20<link>
        ether a2:1f:ee:09:06:5d  txqueuelen 1000  (Ethernet)
        RX packets 50700  bytes 189790729 (189.7 MB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 13008  bytes 902388 (902.3 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 60  bytes 5916 (5.9 KB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 60  bytes 5916 (5.9 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```