### PR TITLE
Fix broken link to Argo Workflows.

### DIFF
--- a/docs/workflows/argo.md
+++ b/docs/workflows/argo.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Workflows on CoreWeave run on [Argo Workflows](https://argoproj.github.io/argo/), which is a great tool to orchestrate parallel execution of GPU and CPU jobs. It manages retries and parallelism for you, and allows you to submit workflows via CLI, [Rest API](https://github.com/argoproj/argo/blob/master/examples/rest-examples.md) and the [Kubernetes API](https://github.com/argoproj/argo/blob/master/docs/rest-api.md).
+Workflows on CoreWeave run on [Argo Workflows](https://argoproj.github.io/argo-workflows/), which is a great tool to orchestrate parallel execution of GPU and CPU jobs. It manages retries and parallelism for you, and allows you to submit workflows via CLI, [Rest API](https://github.com/argoproj/argo/blob/master/examples/rest-examples.md) and the [Kubernetes API](https://github.com/argoproj/argo/blob/master/docs/rest-api.md).
 
 ![Argo Web UI](../../.gitbook/assets/screen-shot-2020-07-29-at-10.04.26-pm.png)
 


### PR DESCRIPTION
Just noticed this URL either changed (and broke this link), or a word was accidentally missed!