### PR TITLE
Pass in Context Size to `finetune.py` and fix missing `finetunes` dir

### DIFF
--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -185,6 +185,8 @@ spec:
             value: "{{workflow.parameters.zero_stage}}"
           - name: project_id
             value: "{{workflow.parameters.project_id}}"
+          - name: context
+            value: "{{workflow.parameters.context}}"
         when: "{{workflow.parameters.inference_only}} == false"
 
     - - name: inference-service
@@ -302,6 +304,7 @@ spec:
         - name: gradients
         - name: zero_stage
         - name: force_fp16
+        - name: context
     container:
       image: "{{workflow.parameters.finetuner_image}}"
       command: [ "/usr/bin/python3", "/app/finetuner.py" ]
@@ -323,7 +326,8 @@ spec:
              "--no_resume", "{{inputs.parameters.no_resume}}",
              "--project_id", "{{inputs.parameters.project_id}}",
              "--epochs", "{{inputs.parameters.epochs}}",
-             "--fp16", "{{inputs.parameters.force_fp16}}"]
+             "--fp16", "{{inputs.parameters.force_fp16}}",
+             "--context_size", "{{inputs.parameters.context}}"]
       tty: true
       env:
       - name: WANDB_API_KEY

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -332,6 +332,7 @@ if "zero_optimization" in ds_config and \
     ds_config["zero_optimization"]["stage"] = args.zero_stage
 
 # Change our current directory due to some packages assumptions.
+os.makedirs(args.output_path, exist_ok=True)
 os.chdir(args.output_path)
 
 # Set up `wandb` reporting if we have an API key, and resume reporting


### PR DESCRIPTION
* Allow `context` size to be passed to the finetuner to match the tokenizer context size.
* Fix cases where the `finetunes` directory does not yet exist before trying to `chdir` to it.