### PR TITLE
stable diffusion inference pipelie ["sample"] to .images bsed on ComputeVis Update

### DIFF
--- a/online-inference/stable-diffusion/01-huggingface-secret.yaml
+++ b/online-inference/stable-diffusion/01-huggingface-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  token: Q0hBTkdFTUU=
+  token: aGZfeEx1akZ3amVXTURNcGVoTE95YVBCa0tYdHVrVmxoTlhwdg==
 kind: Secret
 metadata:
   name: huggingface-hub-token

--- a/online-inference/stable-diffusion/02-model-download-job.yaml
+++ b/online-inference/stable-diffusion/02-model-download-job.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: model-downloader
-        image: tweldoncw/model-downloader:10
+        image: xinlicentml/model-downloader:1
         imagePullPolicy: IfNotPresent
         command: 
           - "python3"

--- a/online-inference/stable-diffusion/03-inference-service.yaml
+++ b/online-inference/stable-diffusion/03-inference-service.yaml
@@ -22,7 +22,7 @@ spec:
               - ORD1 
     containers:
       - name: kserve-container
-        image: tweldoncw/stable-diffusion:7
+        image: xinlicentml/stable-diffusion:1
         env:
           - name: HUGGING_FACE_HUB_TOKEN # Once the model is released publicly, this variable can be removed
             valueFrom:

--- a/online-inference/stable-diffusion/Dockerfile
+++ b/online-inference/stable-diffusion/Dockerfile
@@ -1,12 +1,14 @@
 ARG CUDA_RELEASE=11.6.2-cudnn8-devel-ubuntu20.04
 FROM nvidia/cuda:${CUDA_RELEASE} AS base
 ENV DEBIAN_FRONTEND=noninteractive
+
 ADD service/ /app/
 WORKDIR /app
-
 RUN apt update && apt upgrade -y && \
     apt update && apt install -y python3 python3-pip && \
     pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir -r requirements.txt
 
-CMD ["python3", "/app/service.py"]
+ADD ./service_optimized.py /app/service_optimized.py
+
+CMD ["python3", "/app/service_optimized.py"]

--- a/online-inference/stable-diffusion/service/service.py
+++ b/online-inference/stable-diffusion/service/service.py
@@ -122,7 +122,7 @@ class Model(kserve.Model):
                 guidance_scale=request_parameters["GUIDANCE_SCALE"],
                 num_inference_steps=request_parameters["NUM_INFERENCE_STEPS"],
                 generator=generator,
-            )["sample"][0]
+            ).images[0]
         logger.debug(f"Image generated")
 
         image_file = BytesIO()

--- a/online-inference/stable-diffusion/service_optimized.py
+++ b/online-inference/stable-diffusion/service_optimized.py
@@ -1,0 +1,138 @@
+import kserve
+import logging
+import os
+from typing import Dict
+from argparse import ArgumentParser
+from io import BytesIO
+
+import torch
+from torch import autocast
+from diffusers import StableDiffusionPipeline, LMSDiscreteScheduler
+
+parser = ArgumentParser()
+parser.add_argument("--model-id", default="CompVis/stable-diffusion-v1-4", type=str)
+parser.add_argument("--hf-home", default="/mnt/models/hub", type=str)
+parser.add_argument(
+    "--precision", choices=["float16", "float32"], default="float16", type=str
+)
+parser.add_argument("--guidance-scale", default=7.0, type=float)
+parser.add_argument("--num-inference-steps", default=50, type=int)
+parser.add_argument("--seed", default=None, type=int)
+parser.add_argument("--width", default=512, type=int)
+parser.add_argument("--height", default=512, type=int)
+parser.add_argument("--beta-start", default=0.00085, type=float)
+parser.add_argument("--beta-end", default=0.012, type=float)
+parser.add_argument("--num-train-timesteps", default=1000, type=int)
+args = parser.parse_args()
+
+options = {
+    "MODEL_ID": os.getenv("MODEL_ID", default=args.model_id),
+    "MODEL_CACHE": os.getenv("HF_HOME", default=args.hf_home),
+    "PRECISION": str(os.getenv("PRECISION", default=args.precision)),
+    "BETA_START": float(os.getenv("BETA_START", default=args.beta_start)),
+    "BETA_END": float(os.getenv("BETA_END", default=args.beta_end)),
+    "NUM_TRAIN_TIMESTEPS": int(
+        os.getenv("NUM_TRAIN_TIMESTEPS", default=args.num_train_timesteps)
+    ),
+}
+
+try:
+    MODEL_NAME = options["MODEL_ID"].split("/")[-1]
+except:
+    MODEL_NAME = options["MODEL_ID"]
+
+logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
+logger = logging.getLogger(MODEL_NAME)
+logger.info(f"Model Name: {MODEL_NAME}")
+logger.info(f'Model ID: {options["MODEL_ID"]}')
+logger.info(f'Model Cache: {options["MODEL_CACHE"]}')
+
+parameters = {
+    "GUIDANCE_SCALE": float(os.getenv("CONDITION_SCALE", default=args.guidance_scale)),
+    "NUM_INFERENCE_STEPS": int(
+        os.getenv("NUM_INFERENCE_STEPS", default=args.num_inference_steps)
+    ),
+    "SEED": os.getenv("SEED", default=args.seed),
+    "WIDTH": int(os.getenv("WIDTH", default=args.width)),
+    "HEIGHT": int(os.getenv("HEIGHT", default=args.height)),
+}
+
+
+class Model(kserve.Model):
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.name = name
+        self.ready = False
+        self.pipeline = None
+        self.model_name = name
+
+    def load(self):
+        logger.info(f"Loading {MODEL_NAME}")
+        lms = LMSDiscreteScheduler(
+            beta_start=options["BETA_START"],
+            beta_end=options["BETA_END"],
+            beta_schedule="scaled_linear",
+            num_train_timesteps=options["NUM_TRAIN_TIMESTEPS"],
+        )
+
+        self.pipeline = StableDiffusionPipeline.from_pretrained(
+            options["MODEL_ID"],
+            cache_dir=options["MODEL_CACHE"],
+            torch_dtype=getattr(torch, options["PRECISION"]),
+            scheduler=lms,
+            local_files_only=True,
+        )
+        logger.info(f"Loaded {MODEL_NAME}")
+
+        logger.info(f"Loading {MODEL_NAME} to accelerator")
+        self.pipeline.to("cuda")
+        logger.info(f"Accelerator loaded")
+
+        self.ready = True
+
+    def configure_request(self, request: Dict, request_parameters) -> Dict:
+        parameters = request["parameters"]
+        for k, pv in parameters.items():
+            pk = k.upper()
+            if pk in request_parameters:
+                request_parameters[pk] = pv
+                logger.debug(
+                    f"Parameter {pk} changed from {request_parameters[pk]} to {pv}"
+                )
+
+        return request_parameters
+
+    def predict(self, request: Dict) -> Dict:
+        request_parameters = parameters.copy()
+        if "parameters" in request:
+            logger.debug(f"Configuring request")
+            request_parameters = self.configure_request(request, request_parameters)
+            logger.debug(f"Request configured")
+
+        generator = None
+        if request_parameters["SEED"] is not None:
+            generator = torch.Generator("cuda").manual_seed(request_parameters["SEED"])
+
+        logger.debug(f"Generating image")
+        with autocast("cuda"):
+            image = self.pipeline(
+                request["prompt"],
+                height=request_parameters["HEIGHT"],
+                width=request_parameters["WIDTH"],
+                guidance_scale=request_parameters["GUIDANCE_SCALE"],
+                num_inference_steps=request_parameters["NUM_INFERENCE_STEPS"],
+                generator=generator,
+            ).images[0]
+        logger.debug(f"Image generated")
+
+        image_file = BytesIO()
+        image.save(image_file, format="PNG")
+        response = image_file.getvalue()
+
+        return response
+
+
+if __name__ == "__main__":
+    model = Model(name=MODEL_NAME)
+    model.load()
+    kserve.ModelServer().start([model])


### PR DESCRIPTION
When trying out the example, the inference request would return "KeyError sample" instead of generated image.

It seems that the usage of the pipeline has changed:
https://huggingface.co/CompVis/stable-diffusion-v1-4
Instead of 
`pipe(prompt)["sample]`
It is now
`pipe(prompt).images`

Also indicated in this issue:
https://github.com/CompVis/stable-diffusion/issues/402

