### PR TITLE
Fix diffusers usage error in SD inference example

### DIFF
--- a/online-inference/stable-diffusion/service/service.py
+++ b/online-inference/stable-diffusion/service/service.py
@@ -122,7 +122,7 @@ class Model(kserve.Model):
                 guidance_scale=request_parameters["GUIDANCE_SCALE"],
                 num_inference_steps=request_parameters["NUM_INFERENCE_STEPS"],
                 generator=generator,
-            )["sample"][0]
+            ).images[0]
         logger.debug(f"Image generated")
 
         image_file = BytesIO()


### PR DESCRIPTION
Update diffusers usage in `service.py` to avoid a `KeyError: 'sample'` error when getting the result from the pipeline.  

```
[E 230101 03:53:23 web:1798] Uncaught exception POST /v1/models/stable-diffusion-v1-4:predict (127.0.0.1)
    HTTPServerRequest(protocol='http', host='[snip]', method='POST', uri='/v1/models/stable-diffusion-v1-4:predict', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/dist-packages/tornado/web.py", line 1713, in _execute
        result = await result
      File "/usr/local/lib/python3.8/dist-packages/kserve/handlers/predict.py", line 70, in post
        response = await model(body)
      File "/usr/local/lib/python3.8/dist-packages/kserve/model.py", line 87, in __call__
        else self.predict(request)
      File "/app/service.py", line 118, in predict
        image = self.pipeline(
      File "/usr/local/lib/python3.8/dist-packages/diffusers/utils/outputs.py", line 88, in __getitem__
        return inner_dict[k]
    KeyError: 'sample'
```

See this issue for further details:  https://github.com/CompVis/stable-diffusion/issues/402

I think there was actually a PR in `kubernetes-cloud` earlier from another user, but it had lots of other changes and it was closed.