### PR TITLE
fix: Various sd-finetuner fixes

### DIFF
--- a/online-inference/stable-diffusion/service/requirements.txt
+++ b/online-inference/stable-diffusion/service/requirements.txt
@@ -1,6 +1,6 @@
 kserve==0.9.0
 torch>=1.12.1
 diffusers==0.11.1
-transformers==4.21.1
+transformers==4.26.1
 scipy==1.9.0
 ftfy==6.1.1

--- a/sd-finetuner-workflow/sd-finetune-workflow.yaml
+++ b/sd-finetuner-workflow/sd-finetune-workflow.yaml
@@ -87,10 +87,10 @@ spec:
       value: 'sd-finetune'
     # Inference service configuration.
     - name: run_inference
-      value: 'False'
+      value: false
     # Skip training and only run inference.
     - name: inference_only
-      value: 'False'
+      value: false
     # CoreWeave region to default to; ORD1 has most of the GPUs.
     - name: region
       value: 'ORD1'
@@ -129,6 +129,7 @@ spec:
               value: "/{{workflow.parameters.pvc}}/models/{{workflow.parameters.model}}"
             - name: type
               value: "diffusers"
+        when: "{{workflow.parameters.inference_only}} == false"
 
     - - name: finetuner
         template: model-finetuner
@@ -188,7 +189,7 @@ spec:
             value: "{{workflow.parameters.hf_token}}"
           - name: project_id
             value: "{{workflow.parameters.project_id}}"
-        when: "{{workflow.parameters.inference_only}} == 'False'"
+        when: "{{workflow.parameters.inference_only}} == false"
       
     - - name: inference
         template: model-inference-service
@@ -198,7 +199,7 @@ spec:
               value: "/mnt/pvc/finetunes/{{workflow.parameters.run_name}}"
             - name: hf_home
               value: ""
-        when: "{{workflow.parameters.run_inference}} == 'True'"
+        when: "{{workflow.parameters.run_inference}} == true || {{workflow.parameters.inference_only}} == true"
 
   - name: model-downloader
     inputs:
@@ -208,6 +209,17 @@ spec:
         - name: type
     retryStrategy:
       limit: 1
+    # The model downloader runs as the nonroot user so the dataset folder in the PVC
+    # needs the correct permissions.
+    initContainers:
+      - name: dataset-perms
+        image: alpine:3.17
+        command: [ "/bin/sh" ]
+        args:
+          - "-c"
+          - "mkdir -p {{inputs.parameters.dest}};
+            chmod o+rw,g+s {{inputs.parameters.dest}}"
+        mirrorVolumeMounts: true
     container:
       image: "{{workflow.parameters.downloader_image}}:{{workflow.parameters.downloader_tag}}"
       command: ["/ko-app/model_downloader"]


### PR DESCRIPTION
 - Use bool's instead of strings for 'skip step' parameters
 - Give write permissions for the nonroot model downloader user
 - Update transformers version for the sd finetuning image

This fix comes from investigating [a freshdesk ticket](https://coreweave.freshdesk.com/a/tickets/5740) from a client saying that the sd-finetuner doc page wasn't working properly for them.

After stepping through the docs myself, what I believe happened is the model-downloader didn't download the model bc the nonroot user didn't have the necessary permissions. The model downloader didn't throw an error so the finetuner started. The finetuner also finished successfully right away but if you look at the logs the subprocess threw an error as expected. Looking at the [accelerate source code](https://github.com/huggingface/accelerate/blob/b4388b45dc17e675ffa35769478d3830991d68f4/src/accelerate/commands/launch.py#L683) it looks like the multi-GPU launcher doesn't pass the non-zero exit code up so Argo can't tell that it failed.