### PR TITLE
Update Model-downloader image

### DIFF
--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -116,7 +116,7 @@ spec:
     - name: model_downloader_image
       value: 'ghcr.io/wbrown/gpt_bpe/model_downloader'
     - name: model_downloader_tag
-      value: '7ffb3ec'
+      value: 'e2ef65f'
     - name: dataset_downloader_image
       value: 'ghcr.io/coreweave/dataset-downloader/smashwords-downloader'
     - name: dataset_downloader_tag

--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -276,6 +276,7 @@ spec:
         mirrorVolumeMounts: true
     container:
       image: "{{workflow.parameters.dataset_downloader_image}}:{{workflow.parameters.dataset_downloader_tag}}"
+      command: ["/ko-app/smashwords-downloader"]
       args: ["--data_dir", "{{inputs.parameters.output}}"]
       resources:
         requests:

--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -120,7 +120,7 @@ spec:
     - name: dataset_downloader_image
       value: 'ghcr.io/coreweave/dataset-downloader/smashwords-downloader'
     - name: dataset_downloader_tag
-      value: 'ad27ab2'
+      value: '7dba2c7'
     - name: tokenizer_image
       value: 'ghcr.io/wbrown/gpt_bpe/dataset_tokenizer'
     - name: tokenizer_tag


### PR DESCRIPTION
Updating model-downloader image for the finetuner-workflow from 7ffb3ec to  e2ef65f 

this update allows the model-downloader to support the new metadata version from hugging face, where the merges.txt and vocab.json is included in the tokenizer.json as a key in the json. 