### PR TITLE
LLM Finetuner Update Polish

### DIFF
--- a/finetuner-workflow/finetuner/Dockerfile
+++ b/finetuner-workflow/finetuner/Dockerfile
@@ -12,4 +12,5 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY ds_config.json .
 COPY finetuner.py .
 COPY evaluator.py .
+COPY utils.py .
 CMD [ "/usr/bin/python3", "finetuner.py" ]

--- a/finetuner-workflow/finetuner/evaluator.py
+++ b/finetuner-workflow/finetuner/evaluator.py
@@ -118,7 +118,6 @@ model.eval()
 
 duration = time.time() - start
 print(f"Loaded model in {duration:.2f}s")
-print(MemoryUsage.now())
 torch.cuda.memory.empty_cache()
 print(MemoryUsage.now())
 

--- a/finetuner-workflow/finetuner/evaluator.py
+++ b/finetuner-workflow/finetuner/evaluator.py
@@ -138,9 +138,9 @@ def evaluate(
     """
     output_texts: List[str] = []
     input_tokens: Tensor = (
-        torch.LongTensor(tokenizer.encode(prompt)).unsqueeze(0).to(device)
+        torch.LongTensor(eval_tokenizer.encode(prompt)).unsqueeze(0).to(device)
     )
-    attention_mask: Tensor = input_tokens != tokenizer.pad_token_id
+    attention_mask: Tensor = input_tokens != eval_tokenizer.pad_token_id
     max_length = input_tokens.shape[1] + generate_tokens
 
     generated_tokens = eval_model.generate(

--- a/finetuner-workflow/finetuner/evaluator.py
+++ b/finetuner-workflow/finetuner/evaluator.py
@@ -1,19 +1,13 @@
 #!/bin/which python3
 import argparse
-from typing import Callable, List
+from typing import List
 from torch import Tensor
-import resource
-import pynvml
-import psutil
 import time
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM, PreTrainedTokenizer
-from transformers.modeling_utils import no_init_weights, PreTrainedModel
+from transformers.modeling_utils import PreTrainedModel
 
-try:
-    pynvml.nvmlInit()
-except pynvml.nvml.NVMLError_LibraryNotFound:
-    pynvml = None
+from utils import *
 
 device = torch.device("cpu")
 if torch.cuda.is_available():
@@ -22,68 +16,25 @@ elif torch.backends.mps.is_available():
     device = torch.device("mps")
 
 
-def get_gpu_ram() -> str:
-    """
-    Returns memory usage statistics for the CPU, GPU, and Torch.
+parser = argparse.ArgumentParser(description="Simple Model Evaluator")
 
-    :return:
-    """
-    gpu_str = ""
-    torch_str = ""
-    try:
-        cudadev = torch.cuda.current_device()
-        nvml_device = pynvml.nvmlDeviceGetHandleByIndex(cudadev)
-        gpu_info = pynvml.nvmlDeviceGetMemoryInfo(nvml_device)
-        gpu_total = int(gpu_info.total / 1e6)
-        gpu_free = int(gpu_info.free / 1e6)
-        gpu_used = int(gpu_info.used / 1e6)
-        gpu_str = (
-            f"GPU: (U: {gpu_used:,}mb F: {gpu_free:,}mb "
-            f"T: {gpu_total:,}mb) "
-        )
-        torch_reserved_gpu = int(torch.cuda.memory.memory_reserved() / 1e6)
-        torch_reserved_max = int(torch.cuda.memory.max_memory_reserved() / 1e6)
-        torch_used_gpu = int(torch.cuda.memory_allocated() / 1e6)
-        torch_max_used_gpu = int(torch.cuda.max_memory_allocated() / 1e6)
-        torch_str = (
-            f"TORCH: (R: {torch_reserved_gpu:,}mb/"
-            f"{torch_reserved_max:,}mb, "
-            f"A: {torch_used_gpu:,}mb/{torch_max_used_gpu:,}mb)"
-        )
-    except AssertionError:
-        pass
-    cpu_maxrss = int(
-        resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1e3
-        + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss / 1e3
-    )
-    cpu_vmem = psutil.virtual_memory()
-    cpu_free = int(cpu_vmem.free / 1e6)
-    return (
-        f"CPU: (maxrss: {cpu_maxrss:,}mb F: {cpu_free:,}mb) "
-        f"{gpu_str}"
-        f"{torch_str}"
-    )
-
-
-parser = argparse.ArgumentParser(description='Simple Model Evaluator')
-
-parser.add_argument('--model', type=str, help='the model to evaluate against' +
-                                              ' (directory, or HuggingFace ID)',
+parser.add_argument("--model", type=str, help="the model to evaluate against"
+                                              " (directory, or HuggingFace ID)",
                     required=True)
-parser.add_argument('--tokenizer', type=str, help='the tokenizer to use')
-parser.add_argument('--eot', type=str, help="EOT token to use",
-                    default="<|endoftext|>")
-parser.add_argument('--pad', type=str, help="Pad token to use",
-                    default="<|endoftext|>")
+parser.add_argument("--tokenizer", type=str, help="the tokenizer to use")
+parser.add_argument("--eot", type=str, help="EOT token to use",
+                    default="")  # default is model-dependent
+parser.add_argument("--pad", type=str, help="Pad token to use",
+                    default="")  # default is model-dependent
 parser.add_argument("--cache", type=str, help="Huggingface cache location",
                     default="/tmp")
-parser.add_argument("--fp16", dest='fp16', default=False, action='store_true',
+parser.add_argument("--fp16", dest="fp16", default=False, action="store_true",
                     help="Force training in fp16.")
 parser.add_argument("--prompt", type=str, help="Prompt to use")
 parser.add_argument("--prompt_file", type=str, help="File containing prompts")
 parser.add_argument("--prompt_tokens", type=int, help="Number of tokens to generate",
                     default=200)
-parser.add_argument('--seed', type=int, help="Random seed value",
+parser.add_argument("--seed", type=int, help="Random seed value",
                     default=None)
 parser.add_argument("--prompt_samples", type=int, help="Number of samples to generate",
                     default=1)
@@ -102,101 +53,113 @@ if args.tokenizer is None:
     args.tokenizer = args.model
 
 if args.prompt and args.prompt_file:
-    print("Cannot specify both prompt and prompt-file")
-    exit(1)
+    parser.error("Cannot specify both a prompt and a prompt file")
 
 if not args.prompt and not args.prompt_file:
-    print("Please specify either a prompt or a prompt file")
-    exit(1)
+    parser.error("Please specify either a prompt or a prompt file")
 
 if args.prompt_file:
-    with open(args.prompt_file, "r") as f:
-        prompts = [i.rstrip("\n").replace("\\n", "\n")
-                   for i in f.readlines()]
+    try:
+        with open(args.prompt_file, "r", encoding="utf-8") as f:
+            prompts = (line.rstrip("\n").replace("\\n", "\n") for line in f)
+            prompts = list(filter(None, prompts))
+        if not prompts:
+            parser.error(f"Provided prompt file was blank: {args.prompt_file}")
+    except OSError:
+        parser.error(
+            f"Provided prompt file could not be read: {args.prompt_file}"
+        )
 else:
     prompts = [args.prompt.strip()]
 
 
-def no_init(loading_code: Callable[[], PreTrainedModel]) -> PreTrainedModel:
-    def dummy(self):
-        return
-
-    modules = [torch.nn.Linear, torch.nn.Embedding, torch.nn.LayerNorm]
-    original = {}
-    for mod in modules:
-        original[mod] = mod.reset_parameters
-        mod.reset_parameters = dummy
-
-    with no_init_weights():
-        result = loading_code()
-    for mod in modules:
-        mod.reset_parameters = original[mod]
-
-    return result
-
-print(get_gpu_ram())
+print(MemoryUsage.now())
 
 start = time.time()
 
-tokenizer = AutoTokenizer.from_pretrained(args.tokenizer,
-                                          eos_token=args.eot,
-                                          pad_token=args.pad,
-                                          cache_dir=args.cache,
-                                          padding_side='left')
 
-model = AutoModelForCausalLM.from_pretrained(args.model,
-                                             # Can be a HuggingFace ID or directory.
-                                             cache_dir=args.cache,
-                                             use_cache=True)
+tokens_to_add = {}
+if args.eot:
+    tokens_to_add["eos_token"] = args.eot
+if args.pad:
+    tokens_to_add["pad_token"] = args.pad
 
-if args.fp16:
-    model = no_init(lambda: model.half().to(device))
-else:
-    model = no_init(lambda: model.to(device))
+tokenizer = AutoTokenizer.from_pretrained(
+    args.tokenizer,
+    **tokens_to_add,
+    cache_dir=args.cache,
+    padding_side="left"
+)
 
+tokens_to_add.clear()
+if "eos_token" not in tokenizer.special_tokens_map:
+    tokens_to_add["eos_token"] = "<|endoftext|>"
+if "pad_token" not in tokenizer.special_tokens_map:
+    tokens_to_add["pad_token"] = "<|endoftext|>"
+if tokens_to_add:
+    tokenizer.add_special_tokens(tokens_to_add)
+
+model = AutoModelForCausalLM.from_pretrained(
+    args.model,
+    # Can be a HuggingFace ID or directory.
+    cache_dir=args.cache,
+    use_cache=True
+)
+
+with no_init():
+    if args.fp16:
+        model = model.half().to(device)
+    else:
+        model = model.to(device)
+
+model.resize_token_embeddings(len(tokenizer))
 model.eval()
 
 
 duration = time.time() - start
 print(f"Loaded model in {duration:.2f}s")
-print(get_gpu_ram())
+print(MemoryUsage.now())
 torch.cuda.memory.empty_cache()
-print(get_gpu_ram())
+print(MemoryUsage.now())
 
 
-def evaluate(prompt,
-             generate_tokens: int = 200,
-             num_samples: int = 1,
-             eval_model: PreTrainedModel = model,
-             eval_tokenizer: PreTrainedTokenizer = tokenizer,
-             top_k: int = args.top_k,
-             top_p: float = args.top_p,
-             temperature: float = args.temperature,
-             repetition_penalty: float = args.repetition_penalty) -> List[str]:
+def evaluate(
+    prompt,
+    generate_tokens: int = 200,
+    num_samples: int = 1,
+    eval_model: PreTrainedModel = model,
+    eval_tokenizer: PreTrainedTokenizer = tokenizer,
+    top_k: int = args.top_k,
+    top_p: float = args.top_p,
+    temperature: float = args.temperature,
+    repetition_penalty: float = args.repetition_penalty
+) -> List[str]:
     """
     Evaluate the model on the given prompt, and return the output text.
     """
     output_texts: List[str] = []
-    input_tokens: Tensor = torch.LongTensor(
-        tokenizer.encode(prompt)).unsqueeze(0).to(device)
+    input_tokens: Tensor = (
+        torch.LongTensor(tokenizer.encode(prompt)).unsqueeze(0).to(device)
+    )
+    attention_mask: Tensor = input_tokens != tokenizer.pad_token_id
     max_length = input_tokens.shape[1] + generate_tokens
-    attention_mask: Tensor = torch.ones_like(input_tokens).to(device)
 
-    generated_tokens = eval_model.generate(input_tokens,
-                                           attention_mask=attention_mask,
-                                           max_length=max_length,
-                                           do_sample=True,
-                                           top_k=top_k,
-                                           top_p=top_p,
-                                           temperature=temperature,
-                                           repetition_penalty=repetition_penalty,
-                                           pad_token_id=eval_tokenizer.pad_token_id,
-                                           num_return_sequences=num_samples,
-                                           bad_words_ids=[[eval_tokenizer.eos_token_id]])
+    generated_tokens = eval_model.generate(
+        input_tokens,
+        attention_mask=attention_mask,
+        max_length=max_length,
+        do_sample=True,
+        top_k=top_k,
+        top_p=top_p,
+        temperature=temperature,
+        repetition_penalty=repetition_penalty,
+        pad_token_id=eval_tokenizer.pad_token_id,
+        num_return_sequences=num_samples,
+        bad_words_ids=[[eval_tokenizer.eos_token_id]]
+    )
 
-    for sample_idx in range(len(generated_tokens)):
-        output_text = eval_tokenizer.decode(generated_tokens[sample_idx],
-                                            skip_special_tokens=False)
+    for token in generated_tokens:
+        output_text = eval_tokenizer.decode(token, skip_special_tokens=False)
         output_texts.append(output_text)
 
     return output_texts
@@ -208,7 +171,7 @@ if args.seed is not None:
 for prompt in prompts:
     print("=============================")
     print("PROMPT:", prompt)
-    print("UTILIZATION:", get_gpu_ram())
+    print("UTILIZATION:", MemoryUsage.now())
     for response in evaluate(prompt, args.prompt_tokens, args.prompt_samples):
         print("-----------------------------")
         print("RESPONSE:", response)

--- a/finetuner-workflow/finetuner/evaluator.py
+++ b/finetuner-workflow/finetuner/evaluator.py
@@ -7,8 +7,7 @@ import pynvml
 import psutil
 import time
 import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, PreTrainedTokenizer, \
-    AutoConfig
+from transformers import AutoTokenizer, AutoModelForCausalLM, PreTrainedTokenizer
 from transformers.modeling_utils import no_init_weights, PreTrainedModel
 
 try:
@@ -21,6 +20,7 @@ if torch.cuda.is_available():
     device = torch.device("cuda")
 elif torch.backends.mps.is_available():
     device = torch.device("mps")
+
 
 def get_gpu_ram() -> str:
     """
@@ -63,6 +63,7 @@ def get_gpu_ram() -> str:
         f"{gpu_str}"
         f"{torch_str}"
     )
+
 
 parser = argparse.ArgumentParser(description='Simple Model Evaluator')
 

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -699,7 +699,8 @@ if is_main_process():
 # Rewrite our `ds_config` to match arguments passed in.
 ds_args = {}
 if device != "cpu":
-    ds_config = json.load(open(args.ds_config))
+    with open(args.ds_config) as ds_config_file:
+        ds_config = json.load(ds_config_file)
     if "zero_optimization" in ds_config:
         ds_config["zero_optimization"]["stage"] = args.zero_stage
     ds_args["deepspeed"] = ds_config

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -798,8 +798,10 @@ if estimate_fn:
                 num_nodes=1,
                 num_gpus_per_node=torch.cuda.device_count())
 
-# The latest deepspeed logging is pretty obnoxious, so we disable it.
-deepspeed.utils.logger.setLevel(logging.WARNING)
+# The latest deepspeed logging is pretty obnoxious, so we disable it
+# unless debug-level logging is requested.
+if args.log_level.upper() != "DEBUG":
+    deepspeed.utils.logger.setLevel(logging.WARNING)
 
 # Change our current directory due to some packages assumptions.
 os.makedirs(args.output_path, exist_ok=True)

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -547,7 +547,7 @@ if is_main_process():
     logger.info(f"CONTEXT LENGTH: {args.context_size} tokens")
     logger.info(f"SHUFFLE: {not args.no_shuffle}")
     logger.info(f"EPOCHS {args.epochs}")
-    logger.info(f"CHECKPOINT STEPS: {args.checkpoint_steps}")
+    logger.info(f"CHECKPOINT STEPS: {args.save_steps}")
     logger.info(f"TOKENIZER: {tokenizer}")
     logger.info(f"TOKENIZER SPECIAL TOKENS: {tokenizer.special_tokens_map}")
     logger.info(f"PROMPT FILE: {args.prompt_file}")

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -533,7 +533,7 @@ class TokenizedDataset(Dataset):
 
 
 # Inform the user of host, and various versions -- useful for debugging issues.
-torch.cuda.set_device(args.local_rank)
+torch.cuda.set_device(args.local_rank if args.local_rank != -1 else 0)
 if is_main_process():
     logger.info(f"RUN_NAME: {args.run_name}")
     logger.info(f"PROJECT ID {args.project_id}")

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -543,7 +543,7 @@ if is_main_process():
     logger.info(f"TRANSFORMERS: {transformers.__version__}")
     logger.info(MemoryUsage.now())
     logger.info(f"MODEL: {args.model}")
-    logger.info(f"TRAIN_RATIO: {args.train_ratio}")
+    logger.info(f"TRAIN RATIO: {args.train_ratio}")
     logger.info(f"CONTEXT LENGTH: {args.context_size} tokens")
     logger.info(f"SHUFFLE: {not args.no_shuffle}")
     logger.info(f"EPOCHS {args.epochs}")
@@ -751,9 +751,6 @@ if args.prompt_file:
     ]
 else:
     sampler_callbacks = None
-
-if is_main_process():
-    logger.info(f"PROMPT FILE: {args.prompt_file}")
 
 # Parametrize our training based on provided arguments.
 training_args = TrainingArguments(

--- a/finetuner-workflow/finetuner/requirements.txt
+++ b/finetuner-workflow/finetuner/requirements.txt
@@ -1,13 +1,8 @@
-pandas~=1.5.3
 transformers~=4.27.2
 deepspeed==0.8.3
-tokenizers~=0.13.2
-huggingface-hub~=0.13.3
 numpy~=1.24.2
 pynvml~=11.5.0
 wandb~=0.14.0
 torch==2.0.0
 psutil==5.9.4
-validators
-requests
 accelerate~=0.17.1

--- a/finetuner-workflow/finetuner/requirements.txt
+++ b/finetuner-workflow/finetuner/requirements.txt
@@ -1,7 +1,6 @@
 transformers~=4.27.2
 deepspeed==0.8.3
 numpy~=1.24.2
-pynvml~=11.5.0
 wandb~=0.14.0
 torch==2.0.0
 psutil==5.9.4

--- a/finetuner-workflow/finetuner/utils.py
+++ b/finetuner-workflow/finetuner/utils.py
@@ -1,0 +1,120 @@
+import resource
+from contextlib import contextmanager
+
+from typing import NamedTuple, Optional
+
+import torch
+import psutil
+from transformers.modeling_utils import no_init_weights
+
+__all__ = (
+    "GlobalGPUMemoryUsage",
+    "TorchGPUMemoryUsage",
+    "CPUMemoryUsage",
+    "MemoryUsage",
+    "no_init"
+)
+
+
+class GlobalGPUMemoryUsage(NamedTuple):
+    total: int
+    free: int
+    used: int
+
+    @classmethod
+    def now(cls, device=None):
+        if torch.cuda.is_available():
+            free, total = torch.cuda.mem_get_info(device)
+            return cls(total, free, total - free)
+        else:
+            return None
+
+    def __str__(self):
+        return "GPU: (U: {:,}MiB F: {:,}MiB T: {:,}MiB)".format(
+            self.used >> 20, self.free >> 20, self.total >> 20
+        )
+
+
+class TorchGPUMemoryUsage(NamedTuple):
+    reserved: int
+    reserved_max: int
+    used: int
+    used_max: int
+
+    @classmethod
+    def now(cls, device=None):
+        if torch.cuda.is_available():
+            stats = torch.cuda.memory.memory_stats(device)
+            return cls(
+                stats.get("reserved_bytes.all.current", 0),
+                stats.get("reserved_bytes.all.peak", 0),
+                stats.get("allocated_bytes.all.current", 0),
+                stats.get("allocated_bytes.all.peak", 0)
+            )
+        else:
+            return None
+
+    def __str__(self):
+        return "TORCH: (R: {:,}MiB/{:,}MiB, A: {:,}MiB/{:,}MiB)".format(
+            self.reserved >> 20, self.reserved_max >> 20,
+            self.used >> 20, self.used_max >> 20
+        )
+
+
+class CPUMemoryUsage(NamedTuple):
+    maxrss_kibibytes: int
+    free: int
+
+    @classmethod
+    def now(cls):
+        maxrss = (
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+        )
+        vmem = psutil.virtual_memory()
+        return cls(maxrss, vmem.free)
+
+    def __str__(self):
+        return "CPU: (maxrss: {:,}MiB F: {:,}MiB)".format(
+            self.maxrss_kibibytes >> 10, self.free >> 20
+        )
+
+
+class MemoryUsage(NamedTuple):
+    cpu: CPUMemoryUsage
+    gpu: Optional[GlobalGPUMemoryUsage]
+    torch: Optional[TorchGPUMemoryUsage]
+
+    @classmethod
+    def now(cls):
+        gpu_info = torch_info = None
+        try:
+            gpu_info = GlobalGPUMemoryUsage.now()
+            torch_info = TorchGPUMemoryUsage.now()
+        except AssertionError:
+            pass
+        return cls(CPUMemoryUsage.now(), gpu_info, torch_info)
+
+    def __str__(self):
+        return " ".join(map(str, filter(None, self)))
+
+
+@contextmanager
+def no_init():
+    # `no_init_weights` doesn't suppress initialization of some layers by default
+    # See https://github.com/huggingface/transformers/issues/18505
+    def dummy(self):
+        return
+
+    modules = [torch.nn.Linear, torch.nn.Embedding, torch.nn.LayerNorm]
+    original = {}
+    for mod in modules:
+        original[mod] = mod.reset_parameters
+        mod.reset_parameters = dummy
+
+    try:
+        with no_init_weights():
+            yield
+    finally:
+        for mod in modules:
+            mod.reset_parameters = original[mod]


### PR DESCRIPTION
## Finetuner Update Polish
This PR contains some fixes, improvements, and refactoring to polish off the LLM finetuner update (#128).

### Dataset Splitting (Bug)
When the `no_shuffle` flag was enabled, the finetuner did not correctly respect the train/eval ratio.
It would always use 100% of the dataset for training, and overlap that with the (shuffled, ironically) eval dataset, even though those shouldn't be mixed. This PR changes the implementation to extract a contiguous block (placed randomly) for the eval dataset, and to use the rest of the dataset minus that particular section for the train dataset, all while preserving the original order.

### DeepSpeed Logging (Feature)
DeepSpeed logging is now re-enabled whenever the `--log-level` command line argument to the finetuner is set to `DEBUG`, for maximal information.

### Dependency Pruning
Several of the listed (and even imported) dependencies for the finetuner were outdated and unnecessary, and have been pruned. This should make it easier for us to keep the remaining ones up to date in the future.

### Reducing Drift Between the Finetuner & Evaluator (Refactor + Improvements)
The `evaluator.py` code is largely a subset of the finetuner code. Because of that, it has a lot of repeated function definitions that were originally copied from the finetuner, but which have not kept pace with the finetuner's updates.

Most near-identical chunks of code between the two files have now been updated to the more recent of the two. For example, the evaluator now supports padding and end-of-sentence tokens in the same way that the finetuner does.

This PR also factors out two utility functions shared between the finetuner and the evaluator into a common `utils.py` file: the memory usage check `get_gpu_ram` and `no_init`.

`get_gpu_ram` has been broken down into four granular, reusable classes, `GlobalGPUMemoryUsage`, `TorchGPUMemoryUsage`, `CPUMemoryUsage`, and the collective `MemoryUsage`, which effectively replace all code that had previously queried memory information—e.g. the implementation of `estimate_batch_size`—in an efficient and (hopefully) readable way. It also completely removes the finetuner's direct dependency on `pynvml`, which is now removed from `requirements.txt` as well.

The evaluator has also been given more descriptive error messages when provided invalid arguments, and its code style (method call indentation, single vs. double quotes) has been synced up with the finetuner.

Additionally, the evaluator now always reads prompt files as UTF-8, like the finetuner did, and the finetuner now handles CRLF (and CR) linefeeds in prompt files, like the evaluator did. Sharing is caring!

#### Odd Remaining Bits
At the moment, the evaluator still contains this code:
```py
if args.fp16:
    model = model.half().to(device)
else:
    model = model.to(device)
```
Even though that had been explicitly removed from the finetuner in a previous commit, as it may be more helpful (and correct) in the evaluator in ways that it wasn't for the finetuner. I didn't benchmark it to find out. The datatype casting in both files could likely still use a bit of scrutiny.