### PR TITLE
Fix `kserve` transitive dependency licensing issues

### DIFF
--- a/online-inference/bloom-176b/model/requirements.txt
+++ b/online-inference/bloom-176b/model/requirements.txt
@@ -1,3 +1,6 @@
 accelerate==0.11.0
 git+https://github.com/huggingface/transformers.git@ccc0897 # For device_map in pipelines() support
 kserve==0.8.0.2
+
+# MIT-licensed version of a kserve transitive dependency (necessary for kserve < 0.10.1)
+-e git+https://github.com/AleksTk/table-logger@3cab68c59062ce4d9cb3b667f64e83a23789bf63#egg=table-logger

--- a/online-inference/custom-pytorch-aitextgen/custom-predictor/requirements.txt
+++ b/online-inference/custom-pytorch-aitextgen/custom-predictor/requirements.txt
@@ -2,3 +2,5 @@ kfserving==0.5.1
 aitextgen
 tensorflow
 
+# MIT-licensed version of a kserve transitive dependency (necessary for kfserving/kserve < 0.10.1)
+-e git+https://github.com/AleksTk/table-logger@3cab68c59062ce4d9cb3b667f64e83a23789bf63#egg=table-logger

--- a/online-inference/custom-sentiment/custom-predictor/requirements.txt
+++ b/online-inference/custom-sentiment/custom-predictor/requirements.txt
@@ -1,3 +1,6 @@
 kfserving==0.5.1
 fastai==1.0.61
 torch==1.5.0
+
+# MIT-licensed version of a kserve transitive dependency (necessary for kfserving/kserve < 0.10.1)
+-e git+https://github.com/AleksTk/table-logger@3cab68c59062ce4d9cb3b667f64e83a23789bf63#egg=table-logger

--- a/online-inference/stable-diffusion/service/requirements.txt
+++ b/online-inference/stable-diffusion/service/requirements.txt
@@ -5,3 +5,6 @@ diffusers==0.14.0
 tensorizer==1.0.1
 numpy<1.24.0
 scipy==1.9.0
+
+# MIT-licensed version of a kserve transitive dependency (necessary for kserve < 0.10.1)
+-e git+https://github.com/AleksTk/table-logger@3cab68c59062ce4d9cb3b667f64e83a23789bf63#egg=table-logger


### PR DESCRIPTION
Start of a fix for #183. Docker images still need to be rebuilt and re-published with updated dependencies.

This adds an extra requirement of `-e git+https://github.com/AleksTk/table-logger@3cab68c59062ce4d9cb3b667f64e83a23789bf63#egg=table-logger` alongside older `kserve` and `kfserving` dependencies in the `online-inference` examples.
- There is no PyPI release available with the updated license, so this installs the first Git version of the library with the updated license. It is otherwise identical to the latest PyPI release of `table-logger` (version 0.3.6).
- `-e` (editable mode) is necessary with the Git installation because otherwise the MIT license file isn't properly bundled.