### PR TITLE
feat(spark): Add a spark example

### DIFF
--- a/spark/cpu-pod-template.yaml
+++ b/spark/cpu-pod-template.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cpu-job
+spec:
+  terminationGracePeriodSeconds: 10
+  containers:
+    - name: cpu-job
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+        - name: spark-pvc
+          mountPath: /mnt/pvc
+          readOnly: false
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                  - "LGA1"
+              - key: node.coreweave.cloud/cpu
+                operator: In
+                values:
+                  - amd-epyc-rome
+                  - amd-epyc-milan
+                  - intel-xeon-v3
+                  - intel-xeon-v4
+  volumes:
+    - name: dshm
+      emptyDir:
+        medium: Memory
+    - name: spark-pvc
+      persistentVolumeClaim:
+        claimName: spark-pvc
+        readOnly: false
+  restartPolicy: Always

--- a/spark/docker/Dockerfile
+++ b/spark/docker/Dockerfile
@@ -1,0 +1,14 @@
+ARG SPARK_VERSION="v3.4.0"
+FROM apache/spark-py:$SPARK_VERSION
+
+USER 0
+
+RUN mkdir /app
+
+ARG MSCOCO_SOURCE=https://huggingface.co/datasets/ChristophSchuhmann/MS_COCO_2017_URL_TEXT/resolve/main/mscoco.parquet
+RUN wget $MSCOCO_SOURCE -O /app/mscoco.parquet
+
+ADD requirements.txt /app/requirements.txt
+RUN pip install -r /app/requirements.txt
+
+ADD download_imgdataset.py /app/download_imgdataset.py

--- a/spark/docker/download_imgdataset.py
+++ b/spark/docker/download_imgdataset.py
@@ -1,0 +1,32 @@
+import argparse
+from pathlib import Path
+
+from img2dataset import download
+from pyspark.sql import SparkSession
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--url-list", type=Path, default=Path("/mnt/pvc/mscoco.parquet"), help="Path to the url list file")
+parser.add_argument("--output", type=Path, default=Path("/mnt/pvc/mscoco"), help="Path to output folder")
+parser.add_argument("--thread-count", "-t", type=int, default=16, help="Number of threads for img2dataset")
+args = parser.parse_args()
+
+args.output.mkdir(parents=True, exist_ok=True)
+
+if not args.url_list.exists():
+    raise ValueError(f"The URL list does not exist at: {args.url_list}")
+
+# All options are specified in the spark submit command. Any options specified here will override the spark submit conf
+spark = SparkSession.builder.getOrCreate()
+
+download(
+    thread_count=args.thread_count,  # Process count will be num executors * num cores per executor
+    url_list=str(args.url_list),
+    image_size=256,
+    output_folder=str(args.output),
+    output_format="webdataset",
+    input_format="parquet",
+    url_col="URL",
+    caption_col="TEXT",
+    subjob_size=1000,
+    distributor="pyspark",
+)

--- a/spark/docker/requirements.txt
+++ b/spark/docker/requirements.txt
@@ -1,0 +1,1 @@
+img2dataset==1.41.0

--- a/spark/example-spark-submit.sh
+++ b/spark/example-spark-submit.sh
@@ -4,11 +4,10 @@
 NAMESPACE=$(kubectl config view --minify -o jsonpath='{..namespace}')
 echo "Using the namespace: $NAMESPACE"
 
-# TODO: Change the master back from staging
 $SPARK_HOME/bin/spark-submit \
     --master k8s://https://k8s.ord1.coreweave.com \
     --deploy-mode cluster \
-    --name download-imgdataset-wandb-16-64 \
+    --name download-mscoco-16-64 \
     --conf spark.driver.cores=16 \
     --conf spark.kubernetes.driver.limit.cores=16 \
     --conf spark.driver.memory="64G" \

--- a/spark/example-spark-submit.sh
+++ b/spark/example-spark-submit.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Replace this command with your desired namespace if you don't want to use your default namespace
+NAMESPACE=$(kubectl config view --minify -o jsonpath='{..namespace}')
+echo "Using the namespace: $NAMESPACE"
+
+# TODO: Change the master back from staging
+$SPARK_HOME/bin/spark-submit \
+    --master k8s://https://k8s.ord1.coreweave.com \
+    --deploy-mode cluster \
+    --name download-imgdataset-wandb-16-64 \
+    --conf spark.driver.cores=16 \
+    --conf spark.kubernetes.driver.limit.cores=16 \
+    --conf spark.driver.memory="64G" \
+    --conf spark.executor.cores=16 \
+    --conf spark.kubernetes.executor.limit.cores=16 \
+    --conf spark.executor.memory="64G" \
+    --conf spark.executor.instances=1 \
+    --conf spark.kubernetes.driver.container.image=navarrepratt/spark-download-imgdataset:1.0.2 \
+    --conf spark.kubernetes.executor.container.image=navarrepratt/spark-download-imgdataset:1.0.2 \
+    --conf spark.kubernetes.driver.podTemplateFile=./cpu-pod-template.yaml \
+    --conf spark.kubernetes.executor.podTemplateFile=./cpu-pod-template.yaml \
+    --conf spark.kubernetes.namespace="$NAMESPACE" \
+    --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark-sa \
+    local:///app/download_imgdataset.py --output /mnt/pvc/mscoco -t 2048

--- a/spark/jupyter/interactive-example.ipynb
+++ b/spark/jupyter/interactive-example.ipynb
@@ -1,0 +1,324 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ee8ceb8-e788-4fd4-97f4-aac3c79e41cf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!pip install pyspark img2dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a32f009-a31b-4b8e-8109-ccae087ab4d3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76d6e604-a3f7-4310-9a85-a1022d2bd0c1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# TODO: Update with your namespace\n",
+    "NAMESPACE = \"tenant-sta-nav-npratt\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "SERVICE_NAME = \"spark-jupyter\"\n",
+    "SERVICE_ACCOUNT_NAME = \"spark-sa\""
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54559c2b-b4f8-4a82-9bc0-9e0c84b56750",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "HOSTNAME = !hostname\n",
+    "HOSTNAME = HOSTNAME[0]\n",
+    "HOSTNAME"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a9165fb-37a3-4f3e-b628-f2b63d7684c7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "K8S_API = os.environ[\"KUBERNETES_SERVICE_HOST\"]\n",
+    "K8S_API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4028c48c-9753-46b3-b5d3-276ef7dcb03c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import wandb\n",
+    "\n",
+    "wandb.login()\n",
+    "WANDB_API_KEY = os.environ[\"WANDB_API_KEY\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b46761ee-4f21-407e-88be-f21fcd4b4fd1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%!\n",
+    "echo 'apiVersion: v1\n",
+    "kind: Pod\n",
+    "metadata:\n",
+    "  name: cpu-job\n",
+    "spec:\n",
+    "  terminationGracePeriodSeconds: 10\n",
+    "  containers:\n",
+    "    - name: cpu-job\n",
+    "      volumeMounts:\n",
+    "        - mountPath: /dev/shm\n",
+    "          name: dshm\n",
+    "        - name: spark-pvc\n",
+    "          # Match the mountPath of jupyter lab\n",
+    "          mountPath: /mnt/pvc\n",
+    "          readOnly: false\n",
+    "\n",
+    "  affinity:\n",
+    "    nodeAffinity:\n",
+    "      requiredDuringSchedulingIgnoredDuringExecution:\n",
+    "        nodeSelectorTerms:\n",
+    "          - matchExpressions:\n",
+    "              - key: topology.kubernetes.io/region\n",
+    "                operator: In\n",
+    "                values:\n",
+    "                  - \"LGA1\"\n",
+    "              - key: node.coreweave.cloud/cpu\n",
+    "                operator: In\n",
+    "                values:\n",
+    "                  - amd-epyc-rome\n",
+    "                  - amd-epyc-milan\n",
+    "                  - intel-xeon-v3\n",
+    "                  - intel-xeon-v4\n",
+    "  volumes:\n",
+    "    - name: dshm\n",
+    "      emptyDir:\n",
+    "        medium: Memory\n",
+    "    - name: spark-pvc\n",
+    "      persistentVolumeClaim:\n",
+    "        claimName: spark-pvc\n",
+    "        readOnly: false\n",
+    "  restartPolicy: Always' >> cpu-pod-template.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edcbcf92-3328-4471-9a04-652e62e607b9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "spark = (\n",
+    "    SparkSession.builder\n",
+    "    .appName(\"interactive-test\")\n",
+    "    .config(\"spark.master\", f\"k8s://{K8S_API}\")\n",
+    "    .config(\"spark.submit.deployMode\", \"client\")\n",
+    "    .config(\"spark.driver.port\", \"2222\")\n",
+    "    .config(\"spark.driver.blockManager.port\", \"7777\")\n",
+    "    .config(\"spark.driver.host\", f\"{SERVICE_NAME}.{NAMESPACE}.svc.tenant.chi.local\")\n",
+    "    .config(\"spark.ui.port\", \"4040\")\n",
+    "    .config(\"spark.driver.bindAddress\", \"0.0.0.0\")\n",
+    "\n",
+    "    # Driver config (Resources should match the deployment)\n",
+    "    .config(\"spark.driver.cores\", \"16\")\n",
+    "    .config(\"spark.kubernetes.driver.limit.cores\", \"16\")\n",
+    "    .config(\"spark.driver.memory\", \"64G\")\n",
+    "    .config(\"spark.kubernetes.driver.pod.name\", HOSTNAME)\n",
+    "\n",
+    "    # Executor config\n",
+    "    .config(\"spark.executor.cores\", \"16\")\n",
+    "    .config(\"spark.kubernetes.executor.limit.cores\", \"16\")\n",
+    "    .config(\"spark.executor.memory\", \"64G\")\n",
+    "    .config(\"spark.kubernetes.executor.podNamePrefix\", \"spark-interactive\")\n",
+    "\n",
+    "    # Dynamic scaling config\n",
+    "    .config(\"spark.dynamicAllocation.enabled\", \"true\")\n",
+    "    .config(\"spark.dynamicAllocation.minExecutors\", \"0\")\n",
+    "    .config(\"spark.dynamicAllocation.maxExecutors\", \"5\")\n",
+    "    # .config(\"spark.executor.instances\", 5)\n",
+    "\n",
+    "    # The image has spark v3.4.0 and img2dataset already installed\n",
+    "    .config(\"spark.kubernetes.driver.container.image\", \"navarrepratt/spark-download-imgdataset:1.0.0\")\n",
+    "    .config(\"spark.kubernetes.executor.container.image\", \"navarrepratt/spark-download-imgdataset:1.0.0\")\n",
+    "\n",
+    "    # Use the pod template that was defined in a local file in the previous cell\n",
+    "    .config(\"spark.kubernetes.driver.podTemplateFile\", \"./cpu-pod-template.yaml\")\n",
+    "    .config(\"spark.kubernetes.executor.podTemplateFile\", \"./cpu-pod-template.yaml\")\n",
+    "\n",
+    "    .config(\"spark.kubernetes.namespace\", NAMESPACE)\n",
+    "    .config(\"spark.kubernetes.authenticate.driver.serviceAccountName\", SERVICE_ACCOUNT_NAME)\n",
+    "    .config(\"spark.kubernetes.authenticate.serviceAccountName\", SERVICE_ACCOUNT_NAME)\n",
+    "\n",
+    "    .config(\"spark.kubernetes.driverEnv.WANDB_API_KEY\", WANDB_API_KEY)\n",
+    "    .config(\"spark.executorEnv.WANDB_API_KEY\", WANDB_API_KEY)\n",
+    "\n",
+    "    .getOrCreate()\n",
+    ")\n",
+    "\n",
+    "spark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e57948b-39e8-44f7-b5d3-ffa467bc3d2f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Example workload to calculate Pi\n",
+    "# Meant to spin up all 5 of the dynamic executors defined above.\n",
+    "\n",
+    "from random import random\n",
+    "from operator import add\n",
+    "\n",
+    "partitions = 100\n",
+    "n = 10000000 * partitions\n",
+    "\n",
+    "def f(_):\n",
+    "    x = random() * 2 - 1\n",
+    "    y = random() * 2 - 1\n",
+    "    return 1 if x ** 2 + y ** 2 <= 1 else 0\n",
+    "\n",
+    "count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)\n",
+    "print(\"Pi is roughly %f\" % (4.0 * count / n))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86010d3d-87d5-4024-9df7-61fe223be201",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!wget https://storage.googleapis.com/conceptual_12m/cc12m.tsv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b095a66-1003-4042-b03f-20ea9269ca25",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!sed -i '1s/^/url\\tcaption\\n/' cc12m.tsv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Downlowd the CC12M dataset to the PVC.\n",
+    "# Should take ~1 hour.\n",
+    "\n",
+    "from img2dataset import download\n",
+    "\n",
+    "url_list = \"/mnt/pvc/cc12m.tsv\"\n",
+    "output = \"/mnt/pvc/cc12m-jupyter\"\n",
+    "thread_count = 2048\n",
+    "\n",
+    "download(\n",
+    "    processes_count=1,  # Process count will be num executors * num cores per executor when using pyspark\n",
+    "    thread_count=thread_count,\n",
+    "    url_list=url_list,\n",
+    "    image_size=256,\n",
+    "    output_folder=output,\n",
+    "    output_format=\"webdataset\",\n",
+    "    input_format=\"tsv\",\n",
+    "    url_col=\"url\",\n",
+    "    caption_col=\"caption\",\n",
+    "    enable_wandb=True,\n",
+    "    subjob_size=10000,\n",
+    "    distributor=\"pyspark\",\n",
+    "    timeout=10\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/spark/jupyter/interactive-example.ipynb
+++ b/spark/jupyter/interactive-example.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "# TODO: Update with your namespace\n",
-    "NAMESPACE = \"tenant-sta-nav-npratt\""
+    "NAMESPACE = \"tenant-CHANGE-ME\""
    ]
   },
   {

--- a/spark/jupyter/jupyter-service.yaml
+++ b/spark/jupyter/jupyter-service.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spark-jupyter
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: notebook
+      port: 8888
+      protocol: TCP
+    - name: spark-ui
+      port: 4040
+      protocol: TCP
+    - name: blockmanager
+      port: 7777
+      protocol: TCP
+    - name: driver
+      port: 2222
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: spark-jupyter
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spark-jupyter
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: spark-jupyter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: spark-jupyter
+    spec:
+      serviceAccountName: spark-sa
+      containers:
+        - name: jupyter
+          image: jupyter/all-spark-notebook:python-3.10
+          command:
+            - "jupyter"
+            - "lab"
+            - "--ip"
+            - "0.0.0.0"
+            - "--no-browser"
+            - "--allow-root"
+            - "--notebook-dir"
+            - "/mnt/pvc"
+            - "--LabApp.token=''"
+
+          securityContext:
+            runAsUser: 0
+
+          ports:
+            - name: notebook
+              containerPort: 8888
+              protocol: TCP
+            - name: blockmanager
+              containerPort: 7777
+              protocol: TCP
+            - name: driver
+              containerPort: 2222
+              protocol: TCP
+            - name: spark-ui
+              containerPort: 4040
+              protocol: TCP
+
+          readinessProbe:
+            tcpSocket:
+              port: notebook
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: notebook
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 10
+
+          volumeMounts:
+            - name: storage
+              mountPath: /mnt/pvc
+
+          env:
+            - name: WANDB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: wandb-token-secret
+                  key: token
+
+          resources:
+            requests:
+              cpu: "4"
+              memory: 16Gi
+            limits:
+              cpu: "4"
+              memory: 16Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                  - "LGA1"
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: spark-pvc
+      restartPolicy: Always

--- a/spark/spark-pvc.yaml
+++ b/spark/spark-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spark-pvc
+spec:
+  storageClassName: shared-nvme-lga1
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: "400Gi"

--- a/spark/spark-role.yaml
+++ b/spark/spark-role.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: role:spark
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - services
+      - persistentvolumeclaims
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: role:spark
+subjects:
+  - kind: ServiceAccount
+    name: spark-sa

--- a/spark/wanbd-secret.yaml
+++ b/spark/wanbd-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  token: enterYourSecret==
+kind: Secret
+metadata:
+  name: wandb-token-secret
+type: Opaque


### PR DESCRIPTION
https://github.com/coreweave/docs/issues/228

This PR adds examples of running Spark on Kubernetes. Both of the examples use [img2dataset](https://github.com/rom1504/img2dataset).

The first example runs the spark job in "cluster" mode, and creates the job using `spark-submit`. This is the "simple" example and downloads a small dataset with 1 executor.

The second example involves deploying a service running Jupyter Lab. Then the spark job can be run from within a notebook in client mode. This example uses dynamic executors to scale up and down based on the current jobs, and will use 5 executors to download CC12M in ~1 hour. It includes logging to Weights and Biases.

This PR will stay as a draft until the docs are ready.

TODO Before merge:
- [x] Create docs page
- [x] Confirm security of JupyterLab deployment
