### PR TITLE
More finetuner update fixes.

### DIFF
--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -24,7 +24,11 @@ spec:
     # Whether to retokenize the data on each run. It is strongly recommended to
     # NOT enable this if you are making multiple runs on the same dataset.
     - name: retokenize
-      value: 'false'
+      value: 'true'
+    # Whether to sanitize the data during tokenization,
+    # fixing common whitespace and line-ending issues automatically.
+    - name: sanitize
+      value: 'true'
     # Which tokenizer to use - the dataset_tokenizer internally supports `gpt2`
     # and `pile`. It defaults to the model's tokenizer data if not provided.
     - name: tokenizer
@@ -232,6 +236,8 @@ spec:
             value: "{{workflow.parameters.reorder}}"
           - name: sampling
             value: "{{workflow.parameters.sampling}}"
+          - name: sanitize
+            value: "{{workflow.parameters.sanitize}}"
           - name: retokenize
             value: "{{workflow.parameters.retokenize}}"
         when: "{{workflow.parameters.inference_only}} == false"
@@ -401,6 +407,8 @@ spec:
         - name: boundary_index
         - name: sampling
         - name: reorder
+        - name: sanitize
+        - name: retokenize
     retryStrategy:
       limit: 1
     container:
@@ -416,7 +424,8 @@ spec:
              "-boundary_overlap", "{{inputs.parameters.boundary_index}}",
              "-reorder", "{{inputs.parameters.reorder}}",
              "-sampling", "{{inputs.parameters.sampling}}",
-             "-sanitize"]
+             "-sanitize={{inputs.parameters.sanitize}}",
+             "-retokenize={{inputs.parameters.retokenize}}"]
       resources:
         requests:
           memory: 512Mi

--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -89,8 +89,9 @@ spec:
     - name: repetition_penalty
       value: 1.1
     # Model training parameters
-    - name: train_ratio
-      value: '0.9'
+    # Note: train_ratio is not yet implemented, so it is always 1.0.
+    # - name: train_ratio
+    #  value: '0.9'
     # Batch size. `-1` will let it do a reasonable and relatively conservative
     # guess.
     - name: batch_size
@@ -251,7 +252,7 @@ spec:
               --bs {{workflow.parameters.batch_size}}
               --seed {{workflow.parameters.random_seed}}
               --lr {{workflow.parameters.learn_rate}}
-              --tr {{workflow.parameters.train_ratio}}
+              --train_ratio 1.0
               --output /{{workflow.parameters.pvc}}/finetunes/
               --cache /{{workflow.parameters.pvc}}/cache/
               --logs /{{workflow.parameters.pvc}}/{{workflow.parameters.logs}}

--- a/finetuner-workflow/finetuner/evaluator.py
+++ b/finetuner-workflow/finetuner/evaluator.py
@@ -140,7 +140,12 @@ def evaluate(
     input_tokens: Tensor = (
         torch.LongTensor(eval_tokenizer.encode(prompt)).unsqueeze(0).to(device)
     )
-    attention_mask: Tensor = input_tokens != eval_tokenizer.pad_token_id
+    if eval_tokenizer.pad_token_id != eval_tokenizer.eos_token_id:
+        attention_mask: Tensor = input_tokens != eval_tokenizer.pad_token_id
+    else:
+        # If padding is indistinguishable from end-of-sentence,
+        # we can't tell which to mask, so mask nothing.
+        attention_mask = torch.ones_like(input_tokens, dtype=torch.bool)
     max_length = input_tokens.shape[1] + generate_tokens
 
     generated_tokens = eval_model.generate(

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -685,14 +685,13 @@ numpy.random.seed(args.seed)
 dataset = TokenizedDataset(args.dataset, context_length=args.context_size)
 # FIXME: val_dataset isn't used anywhere, so it is disabled for now.
 if args.train_ratio != 1:
-    logger.warning(
-        "Validation statistics are not yet implemented,"
-        " but data was requested to be set aside"
-        " for the validation set"
-        f" (--train_ratio was set to {args.train_ratio})."
-        " Setting --train_ratio to 1.0"
-        " to not discard training data."
-    )
+    if is_main_process():
+        logger.warning(
+            "Validation statistics are not yet implemented,"
+            " but data was requested to be set aside for the validation set"
+            f" (--train_ratio was set to {args.train_ratio})."
+            " Setting --train_ratio to 1.0 to not discard training data."
+        )
     args.train_ratio = 1
 train_size = int(args.train_ratio * len(dataset))
 val_size = len(dataset) - train_size

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -423,7 +423,7 @@ class ModifiedTrainer(Trainer):
 
     def compute_loss(self, model, inputs, return_outputs=False):
         if "labels" in inputs:
-            inputs["labels"].masked_fill_(inputs["attention_mask"], -100)
+            inputs["labels"].masked_fill_(~inputs["attention_mask"], -100)
 
         results = super().compute_loss(model, inputs, return_outputs)
         loss = results[0] if return_outputs else results

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -810,16 +810,14 @@ if args.log_level.upper() != "DEBUG":
 os.makedirs(args.output_path, exist_ok=True)
 os.chdir(args.output_path)
 
-callbacks = [
-    PerformanceCallback()
-]
+callbacks = [PerformanceCallback()]
 
 # Set up our prompt testing callback if we were given a prompt file.
 if args.prompt_file:
     if args.prompt_every == -1:
         args.prompt_every = args.save_steps
 
-    callbacks += [
+    callbacks.append(
         ModelSampler(
             args.prompt_file,
             tokenizer,
@@ -830,9 +828,7 @@ if args.prompt_file:
             report_every=args.prompt_every or args.save_steps,
             context_size=args.context_size,
         )
-    ]
-else:
-    callbacks = None
+    )
 
 # Parametrize our training based on provided arguments.
 training_args = TrainingArguments(

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -720,7 +720,7 @@ if is_main_process():
 # already.
 model: PreTrainedModel
 
-model_fp16_args = {"torch_dtype": torch.float16}
+model_fp16_args = {"torch_dtype": torch.float16} if args.fp16 else {}
 model_args = {
     "eos_token_id": tokenizer.eos_token_id,
     "pad_token_id": tokenizer.pad_token_id,

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -660,6 +660,15 @@ numpy.random.seed(args.seed)
 # dataset and values dataset -- values dataset is used to test the outcome
 # and determine our loss rate.
 dataset = TokenizedDataset(args.dataset, context_length=args.context_size)
+# FIXME: val_dataset isn't used anywhere, so it is disabled for now.
+if args.train_ratio != 1:
+    logger.warning("Validation statistics are not yet implemented,"
+                   " but data was requested to be set aside"
+                   " for the validation set"
+                   f" (--train_ratio was set to {args.train_ratio})."
+                   " Setting --train_ratio to 1.0"
+                   " to not discard training data.")
+    args.train_ratio = 1
 train_size = int(args.train_ratio * len(dataset))
 val_size = len(dataset) - train_size
 

--- a/finetuner-workflow/finetuner/requirements.txt
+++ b/finetuner-workflow/finetuner/requirements.txt
@@ -1,5 +1,5 @@
 transformers~=4.27.2
-deepspeed==0.9.0
+deepspeed==0.8.3
 numpy~=1.24.2
 wandb~=0.14.0
 torch==2.0.0


### PR DESCRIPTION
# Finetuner fixes and improvements (for #128).
- f23b16dbac077b2134f849a3ab36a3a67b0803d7: Fixed `PerformanceCallback` accidentally being disabled when no `--prompt_file` is given.
- 2f677311320502677f4c6b74ec8c0e98523aa993: Replaced manual GPU-counting with DeepSpeed's world size when calculating the number of contexts trained.
- e37b7d01dd93df1e862b0039dfd671627a23226d: Temporarily disabled `train_ratio` as a workflow parameter.
  - It isn't implemented correctly as-is, and simply discards training data with no benefit.
  - For now, `finetuner.py` emits a warning if it is passed a `--train_ratio` other than `1.0`, and overrides it to `1.0`.
- 9a06e683cb7731b3767d97f485d673692851521f: Stopped masking end-of-sentence tokens as padding if the finetuner can't tell the two apart.
  - This was preventing the finetuner from learning the EOS token and respecting the boundaries between texts under the default settings.
  - As an exception, the final dataset context will still have padding tokens masked even if they are indistinguishable from EOS, since `gpt_bpe` currently only puts padding tokens in the final context (`-reorder=shuffle` notwithstanding).
  - This is still only a workaround; a better solution is to make `gpt_bpe` emit unambiguous token masks at tokenization time.
- 9f0318e8345bb8a860aed938a7c457fbb1b871b3: Fix the workflow's `retokenize` parameter (which did nothing), and expose the tokenizer `-sanitize` flag as a workflow parameter.
  - This additionally changes the default for `retokenize` to `'true'`.
    - The potential confusion that would arise from using an incorrectly tokenized dataset likely outweighs the benefit of optimizing tokenization passes.
    - This way, the optimization can still be enabled when someone knows what they're doing.