### PR TITLE
CURL fixes for GPT finetuner

### DIFF
--- a/finetuner-workflow/finetune-role.yaml
+++ b/finetuner-workflow/finetune-role.yaml
@@ -1,13 +1,19 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: inference
+  name: finetune
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: role:inference
+  name: role:finetune
 rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - 'patch'
   - apiGroups:
       - serving.kubeflow.org
     resources:
@@ -25,11 +31,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: rolebinding:inference-inference
+  name: rolebinding:finetune-finetune
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: role:inference
+  name: role:finetune
 subjects:
   - kind: ServiceAccount
-    name: inference
+    name: finetune

--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -304,9 +304,9 @@ spec:
     retryStrategy:
       limit: 1
     container:
-      image: "alpine:3.12"
+      image: "alpine/curl:3.14"
       command: [ "/bin/sh", "-c" ]
-      args: [ "curl -I -XGET -s -o /dev/null -w \"%{http_code}\" https://accel-object.ord1.coreweave.com/tensorized/{{inputs.parameters.model}}/model.tensors | grep -q 200 && echo -n 'true' > /tmp/output.txt || echo -n 'false' > /tmp/output.txt" ]
+      args: [ "/usr/bin/curl -I -XGET -s -o /dev/null -w \"%{http_code}\" https://accel-object.ord1.coreweave.com/tensorized/{{inputs.parameters.model}}/model.tensors | grep -q 200 && echo -n 'true' > /tmp/output.txt || echo -n 'false' > /tmp/output.txt" ]
     outputs:
       parameters:
         - name: result

--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -4,6 +4,7 @@ metadata:
   generateName: "finetune-"
 spec:
   entrypoint: main
+  serviceAccountName: finetune
   arguments:
     parameters:
     # run_name should be unique on a per-run basis, especially if reporting


### PR DESCRIPTION
`alpine:3.12` apparently did not have CURL installed, replacing with `alpine/curl:3.14` and using an absolute path to the CURL binary fixes this issue where CURL is not found.