### PR TITLE
Finetuner fixes: Random seeding, better empty model loading, more code cleanup

### DIFF
--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -948,6 +948,7 @@ training_args = TrainingArguments(
     output_dir=output_dir,
     run_name=args.run_name,
     disable_tqdm=False,
+    seed=args.seed,
     **ds_args,
     **trainer_fp16_args,
 )

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -28,7 +28,6 @@ from deepspeed.runtime.zero.stage_1_and_2 import (
 from deepspeed.runtime.zero.stage3 import (
     estimate_zero3_model_states_mem_needs_all_live,
 )
-from collections import OrderedDict
 from tensorizer import TensorDeserializer, utils as tensorizer_utils, stream_io
 
 from utils import *
@@ -736,9 +735,7 @@ try:
             **model_fp16_args,
         )
         model = tensorizer_utils.no_init_or_tensor(
-            lambda: AutoModelForCausalLM.from_pretrained(
-                None, config=config, state_dict=OrderedDict()
-            )
+            lambda: AutoModelForCausalLM.from_config(config)
         )
 
         deserializer = TensorDeserializer(args.tensorizer_uri)

--- a/finetuner-workflow/finetuner/utils.py
+++ b/finetuner-workflow/finetuner/utils.py
@@ -96,7 +96,7 @@ class MemoryUsage(NamedTuple):
         return cls(CPUMemoryUsage.now(), gpu_info, torch_info)
 
     def __str__(self):
-        return " ".join(map(str, filter(None, self)))
+        return " ".join(str(item) for item in self if item)
 
 
 @contextmanager


### PR DESCRIPTION
More fixes and improvements for #128.
- 38c5e7e75438c0506f7165176f7497ec7f393b54: Removed the unused `find_free_port` function, since it can't be used with the DeepSpeed launcher.
- f40f0b908b458e4cd7209b6bf72a139fa36c710f: Reorganized `TrainingArguments` constructor arguments and some minor improvements in setting `do_train`, `model.train()`, commenting out unused arguments, etc.
- 1f8e06df01723ed8e852411fb4989c9e850dd3e3: Set the finetuner's seed in the `TrainingArguments` constructor so it will actually be used during finetuning, and not be overwritten.
- 7d7438afa1bf52ce9c40a476425691cf596901dd: Changed initialization of the empty model for the tensorizer loading code to use `AutoModelForCausalLM.from_config()` instead of `AutoModelForCausalLM.from_pretrained()`
  - `AutoModelForCausalLM.from_config()` is specifically designed to be used when creating a model without loading any specific weights, whereas `AutoModelForCausalLM.from_pretrained()` prints a massive warning when used that way.

If we need the `find_free_port()` function later, since it must be used separately among the DeepSpeed launcher's command line arguments, it should be re-added as its own standalone script:
```py
#!/bin/which python3
from contextlib import closing
import socket


def find_free_port():
    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
        s.bind(("", 0))
        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
        return s.getsockname()[1]


if __name__ == "__main__":
    print(find_free_port())
```