### PR TITLE
build(finetuner): Pre-compile CUDA dependencies in another build stage

### DIFF
--- a/finetuner-workflow/finetuner/Dockerfile
+++ b/finetuner-workflow/finetuner/Dockerfile
@@ -1,13 +1,34 @@
-FROM ghcr.io/coreweave/ml-containers/torch:afecfe9-base-cuda11.8.0-torch2.0.0-vision0.15.1
-RUN apt-get install -y cuda-nvcc-11-8 cuda-nvml-dev-11-8 libcurand-dev-11-8 \
-                       libcublas-dev-11-8 libcusparse-dev-11-8 \
-                       libcusolver-dev-11-8 cuda-nvprof-11-8 \
-                       cuda-profiler-api-11-8 \
-                       ninja-build && \
+# syntax=docker/dockerfile:1.2
+
+ARG BASE_IMAGE=ghcr.io/coreweave/ml-containers/torch:afecfe9-base-cuda11.8.0-torch2.0.0-vision0.15.1
+
+# Dependencies requiring NVCC are built ahead of time in a separate stage
+# so that the ~2 GiB dev library installations don't have to be included
+# in the final finetuner image.
+FROM ${BASE_IMAGE} as builder
+RUN apt-get install -y --no-install-recommends \
+        cuda-nvcc-11-8 cuda-nvml-dev-11-8 libcurand-dev-11-8 \
+        libcublas-dev-11-8 libcusparse-dev-11-8 \
+        libcusolver-dev-11-8 cuda-nvprof-11-8 \
+        cuda-profiler-api-11-8 \
+        ninja-build && \
     apt-get clean
+RUN mkdir /wheels
+WORKDIR /wheels
+COPY requirements-precompilable.txt .
+RUN python3 -m pip install -U --no-cache-dir \
+      packaging setuptools wheel pip && \
+    DS_BUILD_UTILS=1 DS_BUILD_CPU_ADAM=1 \
+      python3 -m pip wheel --no-cache-dir \
+      --no-build-isolation --no-deps -r requirements-precompilable.txt
+
+FROM ${BASE_IMAGE}
 RUN mkdir /app
 WORKDIR /app
+RUN --mount=type=bind,from=builder,source=/wheels,target=. \
+    pip3 install --no-cache-dir ./*.whl
 COPY requirements.txt .
+COPY requirements-precompilable.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 COPY ds_config.json .
 COPY finetuner.py .

--- a/finetuner-workflow/finetuner/requirements-precompilable.txt
+++ b/finetuner-workflow/finetuner/requirements-precompilable.txt
@@ -1,0 +1,3 @@
+deepspeed==0.8.3
+flash-attn==1.0.4
+einops==0.6.1

--- a/finetuner-workflow/finetuner/requirements.txt
+++ b/finetuner-workflow/finetuner/requirements.txt
@@ -1,10 +1,8 @@
 transformers~=4.28.1
-deepspeed==0.8.3
 numpy~=1.24.2
 wandb~=0.14.0
 torch==2.0.0
 psutil==5.9.4
 accelerate~=0.17.1
 tensorizer==1.0.1
-einops
-flash-attn
+-r requirements-precompilable.txt


### PR DESCRIPTION
Fix for building the finetuner image in #128.

This separates out compilation of DeepSpeed ops and `flash-attn` into a separate Dockerfile build stage so that their heavy build dependencies (NVCC + ~2 GiB of libraries) don't need to be bundled in the finetuner image. This also fixes building `flash-attn`, which was slightly broken.

These use the `TORCH_CUDA_ARCH_LIST` environment variable inherited from the `torch:base` image to automatically compile for all the architectures supported by the `torch` installation.

Only two DeepSpeed ops are built, specified by `DS_BUILD_UTILS=1 DS_BUILD_CPU_ADAM=1`. There are [more ops in DeepSpeed](https://www.deepspeed.ai/tutorials/advanced-install/), but only these two are used by the finetuner. Building all ops is more complicated and requires extra dependencies (for `DS_BUILD_AIO` and `DS_BUILD_SPARSE_ATTN`, for example). Nonetheless, more flags can be enabled in the Dockerfile if we need them.