### PR TITLE
Updated Inference Server for GPT Finetuner

### DIFF
--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -180,10 +180,6 @@ spec:
       value: 'gooseai/finetuner'
     - name: finetuner_tag
       value: 'cuda-11-8-torch-2-rc10'
-    - name: inference_image
-      value: 'coreweave/ml-images'
-    - name: inference_tag
-      value: 'pytorch-huggingface-81d5ce11'
   templates:
   - name: main
     steps:
@@ -298,7 +294,9 @@ spec:
         arguments:
           parameters:
             - name: model_path
-              value: "finetunes/results-{{workflow.parameters.run_name}}"
+              value: "finetunes/results-{{workflow.parameters.run_name}}/final"
+            - name: model_name
+              value: "final"
         when: "{{workflow.parameters.run_inference}} == true"
   - name: check-model
     inputs:
@@ -529,6 +527,7 @@ spec:
     inputs:
       parameters:
         - name: model_path
+        - name: model_name
     resource:
       action: apply
       manifest: |
@@ -556,17 +555,14 @@ spec:
                           values:
                             - "{{workflow.parameters.region}}"
             containers:
-              - name: kfserving-container
-                image: "{{workflow.parameters.inference_image}}:{{workflow.parameters.inference_tag}}"
+              - name: kserve-container
+                image: "{{workflow.parameters.finetuner_image}}:{{workflow.parameters.finetuner_tag}}"
                 imagePullPolicy: IfNotPresent
-                command:
-                  - "python3"
-                  - "/inference/huggingface.py"
+                command: ["/usr/bin/bash", "-c"]
+                args: ["/usr/bin/python3 /app/inference.py"]
                 env:
                   - name: MODEL_NAME
-                    value: "final"
-                  - name: MODEL_PRECISION
-                    value: "fp16"
+                    value: "{{inputs.parameters.model_name}}"
                   - name: STORAGE_URI # KFServing mounts the PVC at /mnt/pvc/
                     value: pvc://{{ workflow.parameters.pvc }}/
                   - name: MODEL_PATH

--- a/finetuner-workflow/finetuner/Dockerfile
+++ b/finetuner-workflow/finetuner/Dockerfile
@@ -12,5 +12,6 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY ds_config.json .
 COPY finetuner.py .
 COPY evaluator.py .
+COPY inference.py .
 COPY utils.py .
 CMD [ "/usr/bin/python3", "finetuner.py" ]

--- a/finetuner-workflow/finetuner/inference.py
+++ b/finetuner-workflow/finetuner/inference.py
@@ -1,0 +1,71 @@
+import os
+import kserve
+import logging
+import torch
+from typing import Dict
+from transformers import pipeline, AutoModelForCausalLM, AutoTokenizer
+
+logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
+logger = logging.getLogger(__name__)
+
+options = {
+    'MODEL_PATH': os.getenv('MODEL_PATH'),
+    'MODEL_NAME': os.getenv('MODEL_NAME'),
+}
+
+default_params = {
+    'MIN_LENGTH': int(os.getenv('MIN_LENGTH', 1)),
+    'MAX_LENGTH': int(os.getenv('MAX_LENGTH', 100)),
+    'TEMPERATURE': float(os.getenv('TEMPERATURE', 1.0)),
+    'TOP_K': int(os.getenv('TOP_K', 50)),
+    'TOP_P': float(os.getenv('TOP_P', 0.95)),
+    'REPETITION_PENALTY': float(os.getenv('REPETITION_PENALTY', 1.0)),
+    'NUM_RETURN_SEQUENCES': int(os.getenv('NUM_RETURN_SEQUENCES', 1)),
+}
+
+class Model(kserve.Model):
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.name = name
+        self.model_name = name
+        self.ready = False
+    
+    def load(self) -> None:
+        logger.info(f'Loading model from {options["MODEL_PATH"]}')
+        self.model = AutoModelForCausalLM.from_pretrained(options["MODEL_PATH"]).eval()
+        self.tokenizer = AutoTokenizer.from_pretrained(options["MODEL_PATH"])
+        self.generator = pipeline(
+            'text-generation',
+            model=self.model,
+            tokenizer=self.tokenizer,
+            device=0 if torch.cuda.is_available() else -1,
+        )
+        self.ready = True
+
+    def predict(self, request: Dict, headers: Dict) -> Dict:
+        request_params = default_params.copy()
+
+        if 'parameters' in request:
+            parameters = request['parameters']
+            for k, pv in parameters.items():
+                pk = k.upper()
+                if pk in request_params:
+                    logger.debug(f'Parameter {pk} changed from {request_params[pk]} to {pv}')
+                    request_params[pk] = pv
+        
+        return {'predictions': self.generator(
+            request['instances'],
+            do_sample=True,
+            min_length=request_params['MIN_LENGTH'],
+            max_length=request_params['MAX_LENGTH'],
+            temperature=request_params['TEMPERATURE'],
+            top_k=request_params['TOP_K'],
+            top_p=request_params['TOP_P'],
+            repetition_penalty=request_params['REPETITION_PENALTY'],
+        )}
+
+if __name__ == '__main__':
+    model = Model(options['MODEL_NAME'])
+    with torch.no_grad():
+        model.load()
+        kserve.ModelServer().start([model])

--- a/finetuner-workflow/finetuner/requirements.txt
+++ b/finetuner-workflow/finetuner/requirements.txt
@@ -6,6 +6,6 @@ torch==2.0.0
 psutil==5.9.4
 accelerate~=0.17.1
 tensorizer==1.1.0
-einops
-flash-attn
+einops==0.6.1
+flash-attn==1.0.4
 kserve==0.10.1

--- a/finetuner-workflow/finetuner/requirements.txt
+++ b/finetuner-workflow/finetuner/requirements.txt
@@ -5,7 +5,7 @@ wandb~=0.14.0
 torch==2.0.0
 psutil==5.9.4
 accelerate~=0.17.1
-tensorizer==1.0.1
+tensorizer==1.1.0
 einops
 flash-attn
-kserve
+kserve==0.10.1

--- a/finetuner-workflow/finetuner/requirements.txt
+++ b/finetuner-workflow/finetuner/requirements.txt
@@ -8,3 +8,4 @@ accelerate~=0.17.1
 tensorizer==1.0.1
 einops
 flash-attn
+kserve


### PR DESCRIPTION
The previous GPT inference server used in the finetuning example was out of date to the point that it cannot run inference on Pythia or GPT-NeoX models. The changes in this PR also incorporates an inference server with the finetuner image itself for simplicity.

Sidenote, #198 was made out of accident due to me being a little sleep deprived :sweat_smile: 