### PR TITLE
Finetuner inference tweaks

### DIFF
--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -573,7 +573,7 @@ spec:
                           values:
                             - "{{workflow.parameters.region}}"
             containers:
-              - name: http-inference-container
+              - name: kfserving-container
                 image: "{{workflow.parameters.finetuner_image}}:{{workflow.parameters.finetuner_tag}}"
                 imagePullPolicy: IfNotPresent
                 command: ["/usr/bin/bash", "-c"]
@@ -583,6 +583,8 @@ spec:
                     value: "80"
                   - name: INFERENCE_MODEL
                     value: /mnt/pvc/{{ inputs.parameters.model_path }}
+                  - name: STORAGE_URI # KFServing mounts the PVC at /mnt/pvc/
+                    value: pvc://{{ workflow.parameters.pvc }}/
                 ports:
                   - protocol: TCP
                     containerPort: 80

--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -577,14 +577,12 @@ spec:
                 image: "{{workflow.parameters.finetuner_image}}:{{workflow.parameters.finetuner_tag}}"
                 imagePullPolicy: IfNotPresent
                 command: ["/usr/bin/bash", "-c"]
-                args: ["/usr/bin/python3 /app/inference.py"]
+                args: ["/usr/bin/python3 /app/inference.py --model=${INFERENCE_MODEL} --port=${INFERENCE_PORT}"]
                 env:
                   - name: INFERENCE_PORT
                     value: "80"
                   - name: INFERENCE_MODEL
                     value: /mnt/pvc/{{ inputs.parameters.model_path }}
-                  - name: STORAGE_URI # KFServing mounts the PVC at /mnt/pvc/
-                    value: pvc://{{ workflow.parameters.pvc }}/
                 ports:
                   - protocol: TCP
                     containerPort: 80

--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -573,7 +573,7 @@ spec:
                           values:
                             - "{{workflow.parameters.region}}"
             containers:
-              - name: kfserving-container
+              - name: http-inference-container
                 image: "{{workflow.parameters.finetuner_image}}:{{workflow.parameters.finetuner_tag}}"
                 imagePullPolicy: IfNotPresent
                 command: ["/usr/bin/bash", "-c"]

--- a/finetuner-workflow/finetuner/inference.py
+++ b/finetuner-workflow/finetuner/inference.py
@@ -42,7 +42,6 @@ args = parser.parse_args()
 
 class Completion(BaseModel):
     prompt: str
-    engine: Optional[str] = None
     max_new_tokens: Optional[int] = 10
     temperature: Optional[float] = None
     top_p: Optional[float] = None

--- a/finetuner-workflow/finetuner/inference.py
+++ b/finetuner-workflow/finetuner/inference.py
@@ -22,7 +22,7 @@ parser.add_argument(
     "--device-id",
     type=val.non_negative(int, special_val=-1),
     default=0,
-    help="GPU ID to use for inference or -1 for CPU [default = 0]",
+    help="GPU ID to use for inference, or -1 for CPU [default = 0]",
 )
 parser.add_argument(
     "--port",

--- a/finetuner-workflow/finetuner/inference.py
+++ b/finetuner-workflow/finetuner/inference.py
@@ -38,6 +38,7 @@ args = {
     "model": os.getenv("INFERENCE_MODEL", "distilgpt2"),
     "device": int(os.getenv("INFERENCE_DEVICE", 0)),
     "port": int(os.getenv("INFERENCE_PORT", 80)),
+    "ip": os.getenv("INFERENCE_IP", "0.0.0.0"),
 }
 
 model = pipeline(
@@ -73,4 +74,4 @@ def completion(completion: Completion):
 
 
 if __name__ == "__main__":
-    uvicorn.run("inference:app", host="0.0.0.0", port=args["port"])
+    uvicorn.run("inference:app", host=args["ip"], port=args["port"])

--- a/finetuner-workflow/finetuner/inference.py
+++ b/finetuner-workflow/finetuner/inference.py
@@ -54,7 +54,7 @@ def get_health():
 
 
 @app.post("/completion")
-async def completion(completion: Completion):
+def completion(completion: Completion):
     try:
         return model(
             completion.prompt,


### PR DESCRIPTION
Implementing the fixes and tweaks I suggested for finetuner inference in #203.

- Ongoing inference no longer blocks the HTTP server's event loop
- Command line arguments instead of environment variables
  - Extra: IP address can now be specified as a command line argument
  - Extra: Inference on CPU (device ID -1) is fixed by not casting the model to fp16 on CPU
- ~~Renamed the container from `kfserving-container` to `http-inference-container`~~
  - Reverted for compatibility with the Kubernetes-level `kfserving` integration