### PR TITLE
perf(tensorizer-isvc): Use `gunicorn` as a WSGI server with Flask

### DIFF
--- a/online-inference/tensorizer-isvc/gptj_6b_hf/flask/Dockerfile
+++ b/online-inference/tensorizer-isvc/gptj_6b_hf/flask/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY transformer_flask.py ./
 
-ENTRYPOINT ["python", "-m", "gunicorn", "-w8", "-b0.0.0.0", "transformer_flask:app"]
+ENTRYPOINT ["python", "-m", "gunicorn", "-w1", "-b0.0.0.0", "transformer_flask:app"]

--- a/online-inference/tensorizer-isvc/gptj_6b_hf/flask/Dockerfile
+++ b/online-inference/tensorizer-isvc/gptj_6b_hf/flask/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY transformer_flask.py ./
 
-ENTRYPOINT ["python", "transformer_flask.py"]
+ENTRYPOINT ["python", "-m", "gunicorn", "-w8", "-b0.0.0.0", "transformer_flask:app"]

--- a/online-inference/tensorizer-isvc/gptj_6b_hf/flask/requirements.txt
+++ b/online-inference/tensorizer-isvc/gptj_6b_hf/flask/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.3.2
+gunicorn==20.1.0
 transformers==4.27.1

--- a/online-inference/tensorizer-isvc/gptj_6b_tensorizer/flask/Dockerfile
+++ b/online-inference/tensorizer-isvc/gptj_6b_tensorizer/flask/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY tensorizer_flask.py ./
 
-ENTRYPOINT ["python", "tensorizer_flask.py"]
+ENTRYPOINT ["python", "-m", "gunicorn", "-w8", "-b0.0.0.0", "tensorizer_flask:app"]

--- a/online-inference/tensorizer-isvc/gptj_6b_tensorizer/flask/Dockerfile
+++ b/online-inference/tensorizer-isvc/gptj_6b_tensorizer/flask/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY tensorizer_flask.py ./
 
-ENTRYPOINT ["python", "-m", "gunicorn", "-w8", "-b0.0.0.0", "tensorizer_flask:app"]
+ENTRYPOINT ["python", "-m", "gunicorn", "-w1", "-b0.0.0.0", "tensorizer_flask:app"]

--- a/online-inference/tensorizer-isvc/gptj_6b_tensorizer/flask/requirements.txt
+++ b/online-inference/tensorizer-isvc/gptj_6b_tensorizer/flask/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.3.2
+gunicorn==20.1.0
 tensorizer==1.1.0
 transformers==4.27.1


### PR DESCRIPTION
## WSGI Server Performance
Proposed change to the Flask server setups in #204 for `tensorizer-isvc`.

Production deployments usually run Flask through `gunicorn` rather than Flask's embedded webserver for better performance. Setup for it is fairly trivial (adding `gunicorn` as a dependency and launching via `gunicorn` or `python -m gunicorn`), so since the deployed server in this example is expected to be benchmarked, this PR simply switches the Flask `InferenceService`s' Dockerfiles to launch through `gunicorn` instead.