### PR TITLE
feat(finetuner): add adjustable warmup

### DIFF
--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -40,9 +40,6 @@ spec:
     # and `pile`. It defaults to the model's tokenizer data if not provided.
     - name: tokenizer
       value: ''
-    # Save model checkpoint every N steps.
-    - name: save_steps
-      value: '500'
     # How should the tokenizer order the dataset inputs? Options available are:
     # `size_ascending`, `size_descending`, `name_ascending`, `name_descending`,
     # `random`, and `none`. `shuffle` implements `none` while also assigning 
@@ -111,6 +108,9 @@ spec:
     # Note: train_ratio is not yet implemented, so it is always 1.0.
     # - name: train_ratio
     #  value: '0.9'  # range: >= 0, <= 1
+    # Warmup ratio, the percentage of steps to warm up the learning rate for.
+    - name: warmup_ratio
+      value: '0.1'  # range: >= 0, <= 1
     # Batch size. `-1` will let it do a reasonable and relatively conservative
     # guess.
     - name: batch_size
@@ -275,6 +275,7 @@ spec:
               --train-ratio=1.0
               --eot='{{workflow.parameters.eot_token}}'
               --pad='{{workflow.parameters.pad_token}}'
+              --warmup_ratio={{workflow.parameters.warmup_ratio}}
               --bs={{workflow.parameters.batch_size}}
               --bs-divisor={{workflow.parameters.batch_size_divisor}}
               --gradients={{workflow.parameters.gradients}}

--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -275,7 +275,7 @@ spec:
               --train-ratio=1.0
               --eot='{{workflow.parameters.eot_token}}'
               --pad='{{workflow.parameters.pad_token}}'
-              --warmup_ratio={{workflow.parameters.warmup_ratio}}
+              --warmup-ratio={{workflow.parameters.warmup_ratio}}
               --bs={{workflow.parameters.batch_size}}
               --bs-divisor={{workflow.parameters.batch_size_divisor}}
               --gradients={{workflow.parameters.gradients}}

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -979,10 +979,6 @@ if args.prompt_file:
         )
     )
 
-# Calculate how many warmup steps we need to do using the warmup ratio.
-training_steps = int((args.epochs * len(train_dataset)) / (args.gradients * bs * world_size))
-warmup_steps = int(args.warmup_ratio * training_steps)
-
 # Parametrize our training based on provided arguments.
 
 # The grouping of arguments is based on the TrainingArguments.set_<...>
@@ -999,7 +995,7 @@ training_args = TrainingArguments(
     gradient_checkpointing=True,
 
     # Learning rate scheduler arguments
-    warmup_steps=warmup_steps,
+    warmup_steps=float(args.warmup_ratio),
 
     # Evaluation arguments
     # (Evaluation loss tracking is not finished, so these are disabled)

--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -103,6 +103,12 @@ parser.add_argument(
     default=Decimal("0.9"),
 )
 parser.add_argument(
+    "--warmup-ratio",
+    type=val.at_most_1(val.non_negative(Decimal)),
+    help="Ratio of warmup steps to total steps",
+    default=Decimal("0.1"),
+)
+parser.add_argument(
     "--eot",
     type=str,
     help="EOT token to use",
@@ -712,6 +718,7 @@ if is_main_process():
     logger.info(MemoryUsage.now())
     logger.info(f"MODEL: {args.model}")
     logger.info(f"TRAIN RATIO: {args.train_ratio}")
+    logger.info(f"WARMUP RATIO: {args.warmup_ratio}")
     logger.info(f"CONTEXT LENGTH: {args.context_size} tokens")
     logger.info(f"SHUFFLE: {args.shuffle}")
     logger.info(f"EPOCHS: {args.epochs}")
@@ -972,6 +979,10 @@ if args.prompt_file:
         )
     )
 
+# Calculate how many warmup steps we need to do using the warmup ratio.
+training_steps = int((args.epochs * len(train_dataset)) / (args.gradients * bs * world_size))
+warmup_steps = int(args.warmup_ratio * training_steps)
+
 # Parametrize our training based on provided arguments.
 
 # The grouping of arguments is based on the TrainingArguments.set_<...>
@@ -988,7 +999,7 @@ training_args = TrainingArguments(
     gradient_checkpointing=True,
 
     # Learning rate scheduler arguments
-    warmup_steps=8,
+    warmup_steps=warmup_steps,
 
     # Evaluation arguments
     # (Evaluation loss tracking is not finished, so these are disabled)


### PR DESCRIPTION
This PR adds a new argument to #128 which allows clients to adjust the ratio of warm up steps to training steps which is fairly important since the GPT finetuner uses an adaptive optimizer (Adam), plus this also addresses @Eta0's feedback on a duplicate workflow argument.