### PR TITLE
Prevent crashing when using 8 GPUs due to shared memory exhaustion.

### DIFF
--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -525,11 +525,16 @@ spec:
       volumeMounts:
         - mountPath: "/{{workflow.parameters.pvc}}"
           name: "{{workflow.parameters.pvc}}"
+        - name: dshm
+          mountPath: /dev/shm
 
     volumes:
       - name: "{{workflow.parameters.pvc}}"
         persistentVolumeClaim:
            claimName: "{{workflow.parameters.pvc}}"
+      - emptyDir:
+          medium: Memory
+        name: dshm
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This PR is meant to be merged into https://github.com/coreweave/kubernetes-cloud/pull/128 and addresses https://github.com/coreweave/kubernetes-cloud/issues/170 where training crashes when 8 GPUs are allocated but training works just fine with 7 GPUs. So it seems that the training pod was crashing previously due to exhausting shared memory.

This was fixed by creating a shared memory device and currently there is not a specified size limit for it.