### PR TITLE
fix(finetuner): Use correct parameter name when setting `warmup_ratio`

### DIFF
--- a/finetuner-workflow/finetuner/finetuner.py
+++ b/finetuner-workflow/finetuner/finetuner.py
@@ -995,7 +995,7 @@ training_args = TrainingArguments(
     gradient_checkpointing=True,
 
     # Learning rate scheduler arguments
-    warmup_steps=float(args.warmup_ratio),
+    warmup_ratio=float(args.warmup_ratio),
 
     # Evaluation arguments
     # (Evaluation loss tracking is not finished, so these are disabled)


### PR DESCRIPTION
Fix for #128 correcting a variable name typo when setting the `warmup_ratio` parameter that I didn't catch in #217.
- When setting the warmup steps as a ratio in `TrainingArguments`, the parameter name is `warmup_ratio`. It was accidentally left as `warmup_steps`, which is another valid parameter, but which behaves differently.