### PR TITLE
Update CUDA SSH Example

### DIFF
--- a/cuda-ssh/sshd-data-pvc.yaml
+++ b/cuda-ssh/sshd-data-pvc.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: sshd-data-pv-claim
 spec:
-  # https://docs.coreweave.com/coreweave-kubernetes/storage
+  # https://docs.coreweave.com/storage/storage
   storageClassName: block-nvme-ord1
   accessModes:
     - ReadWriteOnce

--- a/cuda-ssh/sshd-data-pvc.yaml
+++ b/cuda-ssh/sshd-data-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sshd-data-pv-claim
 spec:
   # https://docs.coreweave.com/storage/storage
-  storageClassName: block-nvme-ord1
+  storageClassName: block-hdd-ord1
   accessModes:
     - ReadWriteOnce
   resources:

--- a/cuda-ssh/sshd-deployment.yaml
+++ b/cuda-ssh/sshd-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 10
       initContainers:
       - name: init
-        image: ghcr.io/coreweave/ml-containers/cuda-ssh:es-cuda-ssh-87f59b9
+        image: ghcr.io/coreweave/ml-containers/cuda-ssh:es-cuda-ssh-8b9c879-torch-ceeb8c2-nccl-cuda11.8.0-nccl2.16.2-1-torch2.0.1-vision0.15.2-audio2.0.2
         command: ["/bin/bash", "-c"]
         args:
           - |
@@ -40,7 +40,7 @@ spec:
         command: ["/usr/bin/tini", "--"]
         args: ["service", "ssh", "start", "-D"]
         tty: true
-        image: ghcr.io/coreweave/ml-containers/cuda-ssh:es-cuda-ssh-87f59b9
+        image: ghcr.io/coreweave/ml-containers/cuda-ssh:es-cuda-ssh-8b9c879-torch-ceeb8c2-nccl-cuda11.8.0-nccl2.16.2-1-torch2.0.1-vision0.15.2-audio2.0.2
         ports:
           - name: sshd
             containerPort: 22

--- a/cuda-ssh/sshd-deployment.yaml
+++ b/cuda-ssh/sshd-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 10
       initContainers:
       - name: init
-        image: ghcr.io/coreweave/ml-containers/cuda-ssh:es-cuda-ssh-8b9c879-torch-ceeb8c2-nccl-cuda11.8.0-nccl2.16.2-1-torch2.0.1-vision0.15.2-audio2.0.2
+        image: ghcr.io/coreweave/ml-containers/cuda-ssh:209c517-torch-ceeb8c2-nccl-cuda11.8.0-nccl2.16.2-1-torch2.0.1-vision0.15.2-audio2.0.2
         command: ["/bin/bash", "-c"]
         args:
           - |
@@ -40,7 +40,7 @@ spec:
         command: ["/usr/bin/tini", "--"]
         args: ["service", "ssh", "start", "-D"]
         tty: true
-        image: ghcr.io/coreweave/ml-containers/cuda-ssh:es-cuda-ssh-8b9c879-torch-ceeb8c2-nccl-cuda11.8.0-nccl2.16.2-1-torch2.0.1-vision0.15.2-audio2.0.2
+        image: ghcr.io/coreweave/ml-containers/cuda-ssh:209c517-torch-ceeb8c2-nccl-cuda11.8.0-nccl2.16.2-1-torch2.0.1-vision0.15.2-audio2.0.2
         ports:
           - name: sshd
             containerPort: 22

--- a/cuda-ssh/sshd-deployment.yaml
+++ b/cuda-ssh/sshd-deployment.yaml
@@ -17,18 +17,16 @@ spec:
       terminationGracePeriodSeconds: 10
       initContainers:
       - name: init
-        image: atlanticcrypto/cuda-ssh-server:10.2-cudnn
-        command: ["/bin/bash"]
-        args: ["-c", "if [ ! -f /target/initialized ]; then
-                      password=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '');
-                      echo \"root:$password\" | chpasswd;
-                      echo \"Root password is: $password\";
-                      sed -i -e 's/archive.ubuntu.com/mirror.deace.id/' /etc/apt/sources.list;
-                      echo 'Acquire::http::Proxy \"http://10.134.98.2:3128\";' > /etc/apt/apt.conf.d/proxy.conf;
-                      cp -ax / /target;
-                      echo 'Initialization complete';
-                      touch /target/initialized;
-                      fi"]
+        image: ghcr.io/coreweave/ml-containers/cuda-ssh:es-cuda-ssh-87f59b9
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            if [ ! -f /target/initialized ]; then
+              dpkg-reconfigure openssh-server && \
+              cp -ax / /target && \
+              echo 'Initialization complete' && \
+              touch /target/initialized;
+            fi
         resources:
           requests:
             cpu: 1
@@ -39,10 +37,10 @@ spec:
 
       containers:
       - name: sshd
-        command: ["/usr/sbin/sshd"]
-        args: ["-D"]
+        command: ["/usr/bin/tini", "--"]
+        args: ["service", "ssh", "start", "-D"]
         tty: true
-        image: atlanticcrypto/cuda-ssh-server:10.2-cudnn
+        image: ghcr.io/coreweave/ml-containers/cuda-ssh:es-cuda-ssh-87f59b9
         ports:
           - name: sshd
             containerPort: 22
@@ -91,11 +89,11 @@ spec:
 
         resources:
           requests:
-            cpu: 1500m # The CPU unit is mili-cores. 500m is 0.5 cores
-            memory: 4Gi
+            cpu: 2500m # The CPU unit is milli-cores. 500m is 0.5 cores
+            memory: 64Gi
           limits:
             cpu: 7000m
-            memory: 8Gi
+            memory: 128Gi
             nvidia.com/gpu: 6
             # GPUs can only be allocated as a limit, which both reserves and limits the number of GPUs the Pod will have access to
             # Making individual Pods resource light is advantageous for bin-packing. Since this Pod is for general purpose interactive testing
@@ -107,15 +105,15 @@ spec:
       # Read more about affinity at: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
       affinity:
         nodeAffinity:
-          # This will REQUIRE the Pod to be run on a system with a Pascal GPU
+          # This will REQUIRE the Pod to be run on a system with an RTX A5000 GPU
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
               - key: gpu.nvidia.com/class
                 operator: In
                 values:
-                  - NV_Pascal
-              - key: failure-domain.beta.kubernetes.io/region
+                  - RTX_A5000
+              - key: topology.kubernetes.io/region
                 operator: In
                 values:
                   - ORD1

--- a/cuda-ssh/sshd-root-pvc.yaml
+++ b/cuda-ssh/sshd-root-pvc.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: sshd-root-pv-claim
 spec:
-  # https://docs.coreweave.com/coreweave-kubernetes/storage
+  # https://docs.coreweave.com/storage/storage
   storageClassName: block-nvme-ord1
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
# CUDA SSH

This PR brings the deployment for the [`cuda-ssh` docs example](https://docs.coreweave.com/coreweave-kubernetes/examples/cuda-ssh) up to date.

## New Container

The CUDA SSH container has been re-homed from:
- [docker.io/atlanticcrypto/cuda-ssh-server](https://hub.docker.com/r/atlanticcrypto/cuda-ssh-server)

To:

- [ghcr.io/coreweave/ml-containers/cuda-ssh](https://github.com/coreweave/ml-containers/pkgs/container/ml-containers%2Fcuda-ssh)

With the new container based on the NCCL version of [ghcr.io/coreweave/ml-containers/torch](https://github.com/coreweave/ml-containers/pkgs/container/ml-containers%2Ftorch). There is an alternative version of the container built off of the [torch image](https://github.com/coreweave/ml-containers/pkgs/container/ml-containers%2Ftorch)'s base edition that could also be used. The corresponding [coreweave/ml-containers PR is located here](https://github.com/coreweave/ml-containers/pull/20).

## Security Updates

This also includes security updates. Private host keys are no longer embedded in the container image, and instead are generated during initialization. Additionally, public key authentication is now used instead of a randomly-generated password.

To support switching to public key authentication, the accompanying docs for this example will need to be updated as well.

### Documentation Details

The new series of bash commands to set up the server is:

```bash
# Create persistent storage volumes
kubectl apply -f sshd-root-pvc.yaml -f sshd-data-pvc.yaml

# Create the SSH service and public IP
kubectl apply -f sshd-service.yaml

# Launch the SSH server
kubectl apply -f sshd-deployment.yaml

# Wait for the SSH server to come up
kubectl rollout status deployment/sshd

# Add your SSH public key
kubectl exec -i deployment/sshd -c sshd -- /bin/tee --append /root/.ssh/authorized_keys < ~/.ssh/id_rsa.pub

# Print the public IP address
kubectl get service/sshd -o 'jsonpath=service/sshd public IP: {.status.loadBalancer.ingress[0].ip}{"\n"}'

# Print the host key fingerprints
kubectl exec deployment/sshd -c sshd -- find /etc/ssh -type f -name 'ssh_host_*_key.pub' -exec ssh-keygen -lf '{}' ';'

# Connect
ssh root@[public IP]
```

Notes:

- The "Add your SSH public key" step requires the user to have a public SSH key at `~/.ssh/id_rsa.pub`. It's likely that they already have one if they're trying to use an SSH server, but if they don't, running `ssh-keygen` will create one at that path.
  - That line can be modified to use any path to an SSH public key.
- An alternate version of the "Print the public IP address" step could also be `kubectl get service/sshd`, which is simpler and gives more information, whereas the one shown above gives exactly the relevant IP and nothing else.
- The commands listed are for bash, but use minimal shell features.
  - If Windows equivalents are needed, the exact same commands will work in `powershell` with one modification for PowerShell's way of doing input redirection:
    ```diff
    - kubectl exec -i deployment/sshd -c sshd -- /bin/tee --append /root/.ssh/authorized_keys < ~/.ssh/id_rsa.pub
    + Get-Content -Encoding utf8 ~/.ssh/id_rsa.pub | kubectl exec -i deployment/sshd -c sshd -- /bin/tee --append /root/.ssh/authorized_keys
    ```

## Additional Enhancements

- The container now runs with an init process,
- The node affinity has been changed to require `RTX_A5000` GPUs,
- The region selector label has been updated, and
- The pod requests a more appropriate 2.5–7 CPUs and 64–128 GiB RAM to accompany its 6 GPUs, rather than 1.5–7 CPUs and 4–8 GiB RAM.