### PR TITLE
fix(sd-dreambooth-workflow):correct file name typo wandb

### DIFF
--- a/sd-dreambooth-workflow/wanbd-secret.yaml
+++ b/sd-dreambooth-workflow/wanbd-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-data:
-  token: enterYourSecret==
-kind: Secret
-metadata:
-  name: wandb-token-secret
-type: Opaque


### PR DESCRIPTION
Typo in file name: "wanbd-secret.yaml" changed to "wandb-secret.yaml" in path: `/kubernetes-cloud/sd-dreambooth-workflow`.





