### PR TITLE
(fix) bumped nvidia cuda version to 12.2.0

### DIFF
--- a/online-inference/dalle-mini/Dockerfile
+++ b/online-inference/dalle-mini/Dockerfile
@@ -1,5 +1,5 @@
 ARG MODEL=dalle-mini
-ARG CUDA_RELEASE=11.2.1-cudnn8-devel-ubuntu20.04
+ARG CUDA_RELEASE=12.2.0-devel-ubuntu20.04
 FROM nvidia/cuda:${CUDA_RELEASE} AS base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-mark unhold $(apt-mark showhold)


### PR DESCRIPTION
(fix) bumped nvidia cuda version to 12.2.0

verified as working with dall-e models!