### PR TITLE
(fix)bump nvidia cuda version and fix mega mini inconsistencies

### DIFF
--- a/online-inference/dalle-mini/01-model-download-job.yaml
+++ b/online-inference/dalle-mini/01-model-download-job.yaml
@@ -1,8 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  #name: dalle-mini-download
-  name: dalle-mega-download
+  name: dalle-mini-download
+  #name: dalle-mega-download
 spec:
   template:
     spec:
@@ -13,8 +13,8 @@ spec:
         command: 
           - "python3"
           - "/app/download.py"
-          #- "--model-id=dalle-mini/dalle-mini"
-          - "--model-id=dalle-mini/dalle-mega"
+          - "--model-id=dalle-mini/dalle-mini"
+          #- "--model-id=dalle-mini/dalle-mega"
           - "--model-cache=/mnt/pvc"
         volumeMounts:
           - name: model-cache

--- a/online-inference/dalle-mini/02-inference-service.yaml
+++ b/online-inference/dalle-mini/02-inference-service.yaml
@@ -1,8 +1,8 @@
 apiVersion: serving.kubeflow.org/v1beta1
 kind: InferenceService
 metadata:
-  name: dalle-mega
-  #name: dalle-mini
+  #name: dalle-mega
+  name: dalle-mini
 spec:
   predictor:
     containerConcurrency: 1
@@ -29,8 +29,8 @@ spec:
           - "/app/service.py"
         env:
           - name: MODEL_ID
-            value: "dalle-mini/dalle-mega"
-            #value: "dalle-mini/dalle-mini"
+            #value: "dalle-mini/dalle-mega"
+            value: "dalle-mini/dalle-mini"
           - name: MODEL_CACHE
             value: "/mnt/models"
           - name: STORAGE_URI # Kserve mounts the PVC at /mnt/models/

--- a/online-inference/dalle-mini/Dockerfile
+++ b/online-inference/dalle-mini/Dockerfile
@@ -1,5 +1,5 @@
 ARG MODEL=dalle-mini
-ARG CUDA_RELEASE=11.2.1-cudnn8-devel-ubuntu20.04
+ARG CUDA_RELEASE=12.2.0-devel-ubuntu20.04
 FROM nvidia/cuda:${CUDA_RELEASE} AS base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-mark unhold $(apt-mark showhold)


### PR DESCRIPTION
pulling in changes from https://github.com/coreweave/kubernetes-cloud/pull/246 and also fixing the dall-e mega/dall-e mini inconsistencies so that all references point to dall-e mini.