### PR TITLE
(fix) changing base image to ubuntu and addressing minor bugs

### DIFF
--- a/online-inference/stable-diffusion/Dockerfile.downloader
+++ b/online-inference/stable-diffusion/Dockerfile.downloader
@@ -1,7 +1,11 @@
-FROM python:3.9.13-alpine3.16
+FROM ubuntu
+RUN apt-get update 
+RUN apt-get install -y python3 python3-pip 
 RUN mkdir /app
-ADD downloader/ /app/
+ADD downloader/ download.py/app
 WORKDIR /app
+COPY /service/requirements.txt /app/
+RUN pip3 install huggingface_hub
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 CMD ["python3", "/app/download.py"]

--- a/online-inference/stable-diffusion/Dockerfile.downloader
+++ b/online-inference/stable-diffusion/Dockerfile.downloader
@@ -2,7 +2,7 @@ FROM ubuntu
 RUN apt-get update 
 RUN apt-get install -y python3 python3-pip 
 RUN mkdir /app
-ADD downloader/ download.py/app
+ADD downloader/ /app
 WORKDIR /app
 COPY /service/requirements.txt /app/
 RUN pip3 install huggingface_hub

--- a/online-inference/stable-diffusion/service/requirements.txt
+++ b/online-inference/stable-diffusion/service/requirements.txt
@@ -1,5 +1,5 @@
-kserve==0.9.0
-torch>=1.12.1
+kserve
+torch
 transformers~=4.27.1
 diffusers==0.14.0
 tensorizer==1.0.1


### PR DESCRIPTION
Slack Thread: https://coreweave.slack.com/archives/C03L6UD9EJ1/p1693229646897549

This PR intends to unblock users doing the stable diffusion tutorial who want to build their own image of model-downloader locally and push to a public repo like Docker Hub. Users following the current instructions will be blocked due to a bug where the requirements.txt file is not being copied over properly into the working directory AND an incompatibility between alpine and pytorch/numpy. 

The issue is addressed here by modifying the base image to ubuntu, and copying over the proper text files into the working directory to specify requirements.

I was able to build and push an image of `model-downloader` successfully using my modifications.