### PR TITLE
Update finetuner-workflow to allow S3

### DIFF
--- a/finetuner-workflow/finetune-workflow.yaml
+++ b/finetuner-workflow/finetune-workflow.yaml
@@ -17,8 +17,19 @@ spec:
     - name: model
       value: 'EleutherAI/pythia-2.8b-deduped'
     # The directory to read your dataset in, and tokenize for training.
+    # path/to/dataset/ 
     - name: dataset
       value: 'dataset'
+    # if you are reading from pvc or s3 for the dataset
+    - name: datasource
+      value: 'pvc'
+
+    #s3 credentials - secret and access tokens for dataset
+    - name: s3secret
+      value: ''
+
+    - name: s3access
+      value: ''
     # Whether to allow running arbitrary code from HuggingFace model repos.
     # Necessary for some exotic or very new models on HuggingFace.
     # ONLY enable this if a run fails without it, AND you trust the code
@@ -182,21 +193,21 @@ spec:
       value: 'RTX_A5000'
     # Container images -- generally, don't alter this.
     - name: model_downloader_image
-      value: 'ghcr.io/wbrown/gpt_bpe/model_downloader'
+      value: 'ghcr.io/coreweave/gpt_bpe/model_downloader'
     - name: model_downloader_tag
-      value: '7c82f97'
+      value: 'd44973d'
     - name: tokenizer_image
-      value: 'ghcr.io/wbrown/gpt_bpe/dataset_tokenizer'
+      value: 'ghcr.io/coreweave/gpt_bpe/dataset_tokenizer'
     - name: tokenizer_tag
-      value: '7c82f97'
+      value: '5515b56'
     - name: dataset_downloader_image
       value: 'ghcr.io/coreweave/dataset-downloader/smashwords-downloader'
     - name: dataset_downloader_tag
       value: 'cd6408a'
     - name: finetuner_image
-      value: 'gooseai/finetuner'
+      value: 'rexwang8/finetuner'
     - name: finetuner_tag
-      value: 'b32173f'
+      value: 'siete'
   templates:
   - name: main
     steps:
@@ -233,7 +244,7 @@ spec:
         arguments:
           parameters:
           - name: input
-            value: "/{{workflow.parameters.pvc}}/{{workflow.parameters.dataset}}"
+            value: "{{= workflow.parameters.datasource == 's3' ? 's3://' + workflow.parameters.dataset : '/' + workflow.parameters.pvc + '/' + workflow.parameters.dataset }}"
           - name: output
             value: "/{{workflow.parameters.pvc}}/{{workflow.parameters.dataset}}-{{=sprig.replace('/', '_', sprig.replace('.','_', sprig.replace('-','_', workflow.parameters.model)))}}-{{workflow.parameters.context}}-b{{workflow.parameters.boundary_index}}-{{workflow.parameters.tokenizer_tag}}.tokens"
           - name: tokenizer
@@ -438,6 +449,11 @@ spec:
     retryStrategy:
       limit: 1
     container:
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          value: "{{workflow.parameters.s3access}}"
+        - name: AWS_SECRET_ACCESS_KEY
+          value: "{{workflow.parameters.s3secret}}"
       image: "{{workflow.parameters.tokenizer_image}}:{{workflow.parameters.tokenizer_tag}}"
       command: [ "/ko-app/dataset_tokenizer" ]
       args: ["-tokenizer", "{{inputs.parameters.tokenizer}}",
@@ -451,15 +467,16 @@ spec:
              "-reorder", "{{inputs.parameters.reorder}}",
              "-sampling", "{{inputs.parameters.sampling}}",
              "-sanitize={{inputs.parameters.sanitize}}",
+             "-object_storage_endpoint=https://object.ord1.coreweave.com",
              "-retokenize={{inputs.parameters.retokenize}}"]
       securityContext:
         runAsUser: 0
       resources:
         requests:
-          memory: 512Mi
+          memory: 2Gi
           cpu: "4"
         limits:
-          memory: 512Mi
+          memory: 2Gi
           cpu: "4"
       volumeMounts:
         - mountPath: "/{{workflow.parameters.pvc}}"

--- a/finetuner-workflow/finetuner/Dockerfile
+++ b/finetuner-workflow/finetuner/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-ARG BASE_IMAGE=ghcr.io/coreweave/ml-containers/torch:afecfe9-base-cuda11.8.0-torch2.0.0-vision0.15.1
+ARG BASE_IMAGE=ghcr.io/coreweave/ml-containers/torch-extras:29c37fa-nccl-cuda12.0.1-nccl2.18.5-1-torch2.0.1-vision0.15.2-audio2.0.2-flash_attn2.0.2 
 
 # Dependencies requiring NVCC are built ahead of time in a separate stage
 # so that the ~2 GiB dev library installations don't have to be included
@@ -8,37 +8,38 @@ ARG BASE_IMAGE=ghcr.io/coreweave/ml-containers/torch:afecfe9-base-cuda11.8.0-tor
 # gcc-10/g++-10/lld do not need to be installed here, but they improve the build.
 # gfortran-10 is just for compiler_wrapper.f95.
 FROM ${BASE_IMAGE} as builder
-RUN apt-get install -y --no-install-recommends \
-        cuda-nvcc-11-8 cuda-nvml-dev-11-8 libcurand-dev-11-8 \
-        libcublas-dev-11-8 libcusparse-dev-11-8 \
-        libcusolver-dev-11-8 cuda-nvprof-11-8 \
-        cuda-profiler-api-11-8 \
-        ninja-build \
-        gcc-10 g++-10 gfortran-10 lld && \
-    apt-get clean && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
-    update-alternatives --install \
-      /usr/bin/gfortran gfortran /usr/bin/gfortran-10 10 && \
-    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld 1
-RUN mkdir /wheels
-WORKDIR /wheels
-COPY compiler_wrapper.f95 .
-COPY requirements-precompilable.txt .
-RUN gfortran -O3 ./compiler_wrapper.f95 -o ./compiler && \
-    python3 -m pip install -U --no-cache-dir \
-      packaging setuptools wheel pip && \
-    DS_BUILD_UTILS=1 DS_BUILD_CPU_ADAM=1 \
-      CC=$(realpath ./compiler) python3 -m pip wheel \
-      --no-cache-dir --no-build-isolation --no-deps \
-      -r requirements-precompilable.txt && \
-    rm ./compiler_wrapper.f95 ./compiler ./requirements-precompilable.txt
-
+RUN apt-get update
+#RUN apt-get install -y --no-install-recommends \
+#        cuda-nvcc-11-8 cuda-nvml-dev-11-8 libcurand-dev-11-8 \
+#        libcublas-dev-11-8 libcusparse-dev-11-8 \
+#        libcusolver-dev-11-8 cuda-nvprof-11-8 \
+#        cuda-profiler-api-11-8 \
+#        ninja-build \
+#        gcc-10 g++-10 gfortran-10 lld && \
+#    apt-get clean && \
+#    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
+#    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
+#    update-alternatives --install \
+#      /usr/bin/gfortran gfortran /usr/bin/gfortran-10 10 && \
+#    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld 1
+#RUN mkdir /wheels
+#WORKDIR /wheels
+#COPY compiler_wrapper.f95 .
+#COPY requirements-precompilable.txt .
+#RUN gfortran -O3 ./compiler_wrapper.f95 -o ./compiler && \
+#    python3 -m pip install -U --no-cache-dir \
+#      packaging setuptools wheel pip && \
+#    DS_BUILD_UTILS=1 DS_BUILD_CPU_ADAM=1 \
+#      CC=$(realpath ./compiler) python3 -m pip wheel \
+#      --no-cache-dir --no-build-isolation --no-deps \
+#      -r requirements-precompilable.txt && \
+#    rm ./compiler_wrapper.f95 ./compiler ./requirements-precompilable.txt
+#
 FROM ${BASE_IMAGE}
 RUN mkdir /app
 WORKDIR /app
-RUN --mount=type=bind,from=builder,source=/wheels,target=. \
-    pip3 install --no-cache-dir ./*.whl
+#RUN --mount=type=bind,from=builder,source=/wheels,target=. \
+#    pip3 install --no-cache-dir ./*.whl
 COPY requirements.txt .
 COPY requirements-precompilable.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/finetuner-workflow/finetuner/requirements-precompilable.txt
+++ b/finetuner-workflow/finetuner/requirements-precompilable.txt
@@ -1,3 +1,3 @@
-deepspeed==0.9.2
-flash-attn==1.0.4
+flash-attn
+deepspeed
 einops==0.6.1

--- a/finetuner-workflow/finetuner/requirements.txt
+++ b/finetuner-workflow/finetuner/requirements.txt
@@ -1,7 +1,8 @@
 transformers~=4.28.1
 numpy~=1.24.2
 wandb~=0.14.0
-torch==2.0.0
+#torch, flashattn, deepspeed included in torch-extras base img
+torch~=2.0.0
 psutil==5.9.4
 accelerate~=0.17.1
 tensorizer==1.1.0


### PR DESCRIPTION
A bit ago, Rahul updated the tokenizer to allow pulling s3 files as the dataset. This PR accompanies that change and allows the finetuner-workflow to properly use S3.

Changes include:
Updating all the images involved
adding a "s3access" param for the s3 access key, an "s3secret" param for the s3 secret key and a "datasource" param that is either pvc or s3 depending on which source you want to pull from. (pvc default)
Updated the finetuner dockerfile to use a newer version of torch and the torch-extras base image