### PR TITLE
HF LLM Inference: Fixes & style

### DIFF
--- a/online-inference/hf-llm/.dockerignore
+++ b/online-inference/hf-llm/.dockerignore
@@ -1,0 +1,5 @@
+*
+!serializer/requirements.txt
+!serializer/*.py
+!service/requirements.txt
+!service/*.py

--- a/online-inference/hf-llm/00-optional-s3-secret.yaml
+++ b/online-inference/hf-llm/00-optional-s3-secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 data:
-  access_key: Replace_this_with_your_access_key
-  secret_key: Replace_this_with_your_secret_key
-  host_url: Replace_this_with_your_host_url
+  access_key: Replace_this_with_your_base64_encoded_access_key
+  secret_key: Replace_this_with_your_base64_encoded_secret_key
+  host_url: Replace_this_with_your_base64_encoded_host_url
 kind: Secret
 metadata:
   name: s3-credentials

--- a/online-inference/hf-llm/01-optional-s3-serialize-job.yaml
+++ b/online-inference/hf-llm/01-optional-s3-serialize-job.yaml
@@ -16,17 +16,17 @@ spec:
           - "--precision=float16"
           - "--dest-bucket=your-bucket-here"
         env:
-        - name: AWS_KEY
+        - name: S3_KEY
           valueFrom:
             secretKeyRef:
               name: s3-credentials
               key: access_key
-        - name: AWS_SECRET
+        - name: S3_SECRET
           valueFrom:
             secretKeyRef:
               name: s3-credentials
               key: secret_key
-        - name: AWS_HOST
+        - name: S3_HOST
           valueFrom:
             secretKeyRef:
               name: s3-credentials

--- a/online-inference/hf-llm/02-inference-service.yaml
+++ b/online-inference/hf-llm/02-inference-service.yaml
@@ -36,19 +36,19 @@ spec:
         - "--precision=float16"
         - "--port=80"
         env:
-        - name: AWS_KEY
+        - name: S3_KEY
           valueFrom:
             secretKeyRef:
               name: s3-credentials
               key: access_key
               optional: true
-        - name: AWS_SECRET
+        - name: S3_SECRET
           valueFrom:
             secretKeyRef:
               name: s3-credentials
               key: secret_key
               optional: true
-        - name: AWS_HOST
+        - name: S3_HOST
           valueFrom:
             secretKeyRef:
               name: s3-credentials

--- a/online-inference/hf-llm/serializer/serialize.py
+++ b/online-inference/hf-llm/serializer/serialize.py
@@ -1,8 +1,9 @@
-import torch
-import os
 import logging
-from tensorizer import TensorSerializer, stream_io
+import os
 from argparse import ArgumentParser
+
+import torch
+from tensorizer import TensorSerializer, stream_io
 from transformers import AutoModelForCausalLM
 
 logging.basicConfig(level=logging.INFO)
@@ -14,10 +15,22 @@ s3_endpoint_default = os.getenv("S3_HOST") or "object.ord1.coreweave.com"
 
 parser = ArgumentParser()
 parser.add_argument("--hf-model-id", default="distilgpt2", type=str)
-parser.add_argument("--precision", choices=["float16", "float32"], default="float16", type=str)
+parser.add_argument(
+    "--precision", choices=["float16", "float32"], default="float16", type=str
+)
 parser.add_argument("--dest-bucket", required=True, type=str)
-parser.add_argument("--s3-access-key", default=s3_access_key_default, required=s3_access_key_default is None, type=str)
-parser.add_argument("--s3-secret-access-key", default=s3_secret_access_key_default, required=s3_secret_access_key_default is None, type=str)
+parser.add_argument(
+    "--s3-access-key",
+    default=s3_access_key_default,
+    required=s3_access_key_default is None,
+    type=str,
+)
+parser.add_argument(
+    "--s3-secret-access-key",
+    default=s3_secret_access_key_default,
+    required=s3_secret_access_key_default is None,
+    type=str,
+)
 parser.add_argument("--s3-endpoint", default=s3_endpoint_default, type=str)
 args = parser.parse_args()
 
@@ -30,7 +43,7 @@ def save_artifact_s3(model, path):
             s3_access_key_id=args.s3_access_key,
             s3_secret_access_key=args.s3_secret_access_key,
             s3_endpoint=args.s3_endpoint,
-            s3_config_path=None
+            s3_config_path=None,
         )
     )
     serializer.write_module(model)
@@ -42,7 +55,9 @@ if __name__ == "__main__":
     model_id = args.hf_model_id
     model = AutoModelForCausalLM.from_pretrained(
         model_id,
-        torch_dtype=torch.float16 if args.precision == "float16" else torch.float32
+        torch_dtype=torch.float16
+        if args.precision == "float16"
+        else torch.float32,
     )
 
     model_file = "fp16/model.tensors" if args.precision == "float16" else ""

--- a/online-inference/hf-llm/serializer/serialize.py
+++ b/online-inference/hf-llm/serializer/serialize.py
@@ -8,13 +8,17 @@ from transformers import AutoModelForCausalLM
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
 
+s3_access_key_default = os.getenv("S3_KEY") or None
+s3_secret_access_key_default = os.getenv("S3_SECRET") or None
+s3_endpoint_default = os.getenv("S3_HOST") or "object.ord1.coreweave.com"
+
 parser = ArgumentParser()
 parser.add_argument("--hf-model-id", default="distilgpt2", type=str)
 parser.add_argument("--precision", choices=["float16", "float32"], default="float16", type=str)
-parser.add_argument("--dest-bucket", default=None, required=True, type=str)
-parser.add_argument("--s3-access-key", default=os.getenv("AWS_KEY"), required=False, type=str)
-parser.add_argument("--s3-secret-access-key", default=os.getenv("AWS_SECRET"), required=False, type=str)
-parser.add_argument("--s3-endpoint", default=os.getenv("AWS_HOST", "object.ord1.coreweave.com"), required=False, type=str)
+parser.add_argument("--dest-bucket", required=True, type=str)
+parser.add_argument("--s3-access-key", default=s3_access_key_default, required=s3_access_key_default is None, type=str)
+parser.add_argument("--s3-secret-access-key", default=s3_secret_access_key_default, required=s3_secret_access_key_default is None, type=str)
+parser.add_argument("--s3-endpoint", default=s3_endpoint_default, type=str)
 args = parser.parse_args()
 
 

--- a/online-inference/hf-llm/serializer/serialize.py
+++ b/online-inference/hf-llm/serializer/serialize.py
@@ -45,8 +45,7 @@ if __name__ == "__main__":
         torch_dtype=torch.float16 if args.precision == "float16" else torch.float32
     )
 
-    BASE_S3_URL = f"s3://{args.dest_bucket}/"
-    DTYPE_STR = "/fp16" if args.precision == "float16" else ""
+    model_file = "fp16/model.tensors" if args.precision == "float16" else ""
+    uri = "s3://" + "/".join((args.dest_bucket, model_id, model_file))
 
-    save_artifact_s3(model, BASE_S3_URL + model_id +
-                     DTYPE_STR + "/model.tensors")
+    save_artifact_s3(model, uri)

--- a/online-inference/hf-llm/service/service.py
+++ b/online-inference/hf-llm/service/service.py
@@ -19,15 +19,22 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
 
 # Argument parser setup
+model_uri_default = (
+    os.getenv("MODEL_URI") or "s3://tensorized/EleutherAI/pythia-70m"
+)
+s3_access_key_default = os.getenv("S3_KEY") or None
+s3_secret_access_key_default = os.getenv("S3_SECRET") or None
+s3_endpoint_default = os.getenv("S3_HOST") or "accel-object.ord1.coreweave.com"
+
 parser = ArgumentParser()
-parser.add_argument("--model-uri", default=os.getenv("MODEL_URI", "s3://tensorized/EleutherAI/pythia-70m"), type=str)
+parser.add_argument("--model-uri", default=model_uri_default, type=str)
 parser.add_argument("--precision", choices=["float16", "float32"], default="float16", type=str)
 parser.add_argument("--device-id", default=0, help="GPU ID to use for inference, or -1 for CPU [default = 0]")
 parser.add_argument("--port", default=80, help="Port to listen on [default = 80 (http)]", type=int)
 parser.add_argument("--ip", type=str, default="0.0.0.0", help="IP address to listen on [default = 0.0.0.0 (all interfaces)]")
-parser.add_argument("--s3-access-key", default=os.getenv("AWS_KEY"), type=str)
-parser.add_argument("--s3-secret-access-key", default=os.getenv("AWS_SECRET"), type=str)
-parser.add_argument("--s3-endpoint", default=os.getenv("AWS_HOST", "accel-object.ord1.coreweave.com"), type=str)
+parser.add_argument("--s3-access-key", default=s3_access_key_default, type=str)
+parser.add_argument("--s3-secret-access-key", default=s3_secret_access_key_default, type=str)
+parser.add_argument("--s3-endpoint", default=s3_endpoint_default, type=str)
 args = parser.parse_args()
 
 

--- a/online-inference/hf-llm/service/service.py
+++ b/online-inference/hf-llm/service/service.py
@@ -1,18 +1,24 @@
-import os
-import time
-import uvicorn
 import json
-import torch
 import logging
+import os
+import re
+import time
 import traceback
-import tensorizer
 from argparse import ArgumentParser
-from pydantic import BaseModel
-from typing import Optional, List
+from typing import List, Optional
+
+import tensorizer
+import torch
+import uvicorn
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
-from transformers import (TextGenerationPipeline, AutoConfig,
-                          AutoTokenizer, AutoModelForCausalLM)
+from pydantic import BaseModel
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    TextGenerationPipeline,
+)
 
 # Logger setup
 logging.basicConfig(level=logging.INFO)
@@ -28,12 +34,30 @@ s3_endpoint_default = os.getenv("S3_HOST") or "accel-object.ord1.coreweave.com"
 
 parser = ArgumentParser()
 parser.add_argument("--model-uri", default=model_uri_default, type=str)
-parser.add_argument("--precision", choices=["float16", "float32"], default="float16", type=str)
-parser.add_argument("--device-id", default=0, help="GPU ID to use for inference, or -1 for CPU [default = 0]")
-parser.add_argument("--port", default=80, help="Port to listen on [default = 80 (http)]", type=int)
-parser.add_argument("--ip", type=str, default="0.0.0.0", help="IP address to listen on [default = 0.0.0.0 (all interfaces)]")
+parser.add_argument(
+    "--precision", choices=["float16", "float32"], default="float16", type=str
+)
+parser.add_argument(
+    "--device-id",
+    default=0,
+    help="GPU ID to use for inference, or -1 for CPU [default = 0]",
+)
+parser.add_argument(
+    "--port",
+    default=80,
+    help="Port to listen on [default = 80 (http)]",
+    type=int,
+)
+parser.add_argument(
+    "--ip",
+    type=str,
+    default="0.0.0.0",
+    help="IP address to listen on [default = 0.0.0.0 (all interfaces)]",
+)
 parser.add_argument("--s3-access-key", default=s3_access_key_default, type=str)
-parser.add_argument("--s3-secret-access-key", default=s3_secret_access_key_default, type=str)
+parser.add_argument(
+    "--s3-secret-access-key", default=s3_secret_access_key_default, type=str
+)
 parser.add_argument("--s3-endpoint", default=s3_endpoint_default, type=str)
 args = parser.parse_args()
 
@@ -48,7 +72,7 @@ def load_artifact(path_uri: str, module: torch.nn.Module) -> None:
             s3_endpoint=args.s3_endpoint,
             s3_config_path=None,
         ),
-        plaid_mode=True
+        plaid_mode=True,
     )
     deserializer.load_into_module(module)
     deserializer.close()
@@ -93,14 +117,18 @@ def load_model_s3(path_uri: str) -> TextGenerationPipeline:
     end = time.monotonic()
     logger.info(f"Model loaded successfully in {end - start:.2f} seconds")
 
-    return TextGenerationPipeline(model=model, tokenizer=tokenizer, device=args.device_id)
+    return TextGenerationPipeline(
+        model=model, tokenizer=tokenizer, device=args.device_id
+    )
 
 
 def load_model_local(path_uri: str) -> TextGenerationPipeline:
     dtype = torch.float16 if args.precision == "float16" else torch.float32
     model = AutoModelForCausalLM.from_pretrained(path_uri, torch_dtype=dtype)
     tokenizer = AutoTokenizer.from_pretrained(path_uri)
-    return TextGenerationPipeline(model=model, tokenizer=tokenizer, device=args.device_id)
+    return TextGenerationPipeline(
+        model=model, tokenizer=tokenizer, device=args.device_id
+    )
 
 
 def load_model(path_uri: str) -> TextGenerationPipeline:
@@ -159,9 +187,13 @@ async def completion(completion: Completion):
             do_sample=completion.do_sample,
             penalty_alpha=completion.penalty_alpha,
             num_return_sequences=completion.num_return_sequences,
-            stop_sequence=completion.stop_sequence
+            stop_sequence=completion.stop_sequence,
         )
-        return Response(content=json.dumps(output), media_type="application/json", status_code=200)
+        return Response(
+            content=json.dumps(output),
+            media_type="application/json",
+            status_code=200,
+        )
     except Exception as e:
         logger.error(traceback.format_exc())
         return Response(


### PR DESCRIPTION
# HF LLM Inference Fixes

Fixes and polish for #303.

The `load_model_s3` code in `service/service.py` was somewhat brittle on account of parsing the `path_uri` name for a slash-separated HuggingFace ID. It failed when attempting to follow the default example of serializing and deserializing `distilgpt2` because it is an example of a single-component HuggingFace ID with no slashes: it picks up the bucket name as the first component and then breaks (for example: `s3://my-bucket/distilgpt2` picks up `hf_id == my-bucket/distilgpt2`). It also broke for other models if you add a trailing slash to the ID, or if you included the `/model.tensors` or `/fp16/model.tensors` segments, and so on.

This change switches it to use more robust regex parsing that normalizes all of these cases, e.g.:
- ✔️ `s3://tensorized/EleutherAI/pythia-70m`
- `s3://tensorized/EleutherAI/pythia-70m/` → ✔️ `s3://tensorized/EleutherAI/pythia-70m`
- `s3://tensorized/EleutherAI/pythia-70m/fp16/model.tensors` → ✔️ `s3://tensorized/EleutherAI/pythia-70m`
- ✔️ `s3://my-bucket/distilgpt2`
- `s3://my-bucket/distilgpt2/` → ✔️ `s3://my-bucket/distilgpt2`
- `s3://my-bucket/distilgpt2/fp16/` → ✔️ `s3://my-bucket/distilgpt2`
- `s3://my-bucket/distilgpt2/model.tensors` → ✔️ `s3://my-bucket/distilgpt2`

Additional changes:
- More robust argument parsing was added where environment variables are used as defaults, recognizing empty strings as a lack of a value,
- A `.dockerignore` has been added to prevent the Docker build context from ever seeing any secrets written into the secret manifest,
- The secret manifest now mentions that data strings should be base64-encoded, and
- Code style is normalized with `isort` & `black -l80`.