### PR TITLE
fix: Broken URL to documentation

### DIFF
--- a/online-inference/tensorizer-isvc/README.md
+++ b/online-inference/tensorizer-isvc/README.md
@@ -1,7 +1,7 @@
 # GPT-J InferenceService with Tensorizer & HuggingFace
 
 The following instructions will guide you through setting up an
-[InferenceService](https://docs.coreweave.com/machine-learning-and-ai/inference/online-inference)
+[InferenceService](https://docs.coreweave.com/coreweave-machine-learning-and-ai/how-to-guides-and-tutorials/examples)
 with [Tensorizer](https://github.com/coreweave/tensorizer)
 or [HuggingFace Transformers](https://huggingface.co/docs/transformers/index)
 serving [GPT-J-6B](https://huggingface.co/EleutherAI/gpt-j-6b).


### PR DESCRIPTION
Corrects the reported broken link.

Closes [DOCS-467](https://coreweave.atlassian.net/browse/DOCS-467)

[DOCS-467]: https://coreweave.atlassian.net/browse/DOCS-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ