### PR TITLE
feat(spark): Add pod/logs to role

### DIFF
--- a/spark/spark-role.yaml
+++ b/spark/spark-role.yaml
@@ -13,6 +13,7 @@ rules:
     resources:
       - configmaps
       - pods
+      - pods/log
       - services
       - persistentvolumeclaims
     verbs:


### PR DESCRIPTION
Accessing logs from the Spark driver is helpful for:

- Debugging failed jobs: Driver logs contain detailed error messages and stack traces
- Performance monitoring: Understanding bottlenecks and resource utilization
- Application monitoring: Real-time visibility into job progress and status
- Troubleshooting: Diagnosing issues with executor allocation, data processing, or connectivity
- Compliance: Meeting logging requirements for audit purposes

The `pods/log` permission allows the Spark driver (or monitoring tools) to programmatically access logs from executor pods, enabling comprehensive observability of the entire Spark application lifecycle.